### PR TITLE
Enable Gmail emails for completed courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Application web permettant à l'entreprise Agri Holann de planifier les tournée
 
 - **Authentification simplifiée** : recherche et connexion d'un chauffeur par son nom de famille, accès dédié à l'administration.
 - **Tableaux de bord** : vue chauffeur (courses du jour et de la semaine) et vue administrateur (planning global, filtres par chauffeur, journal des activités).
-- **Comptes administrateurs** : création et connexion d'un compte dont l'identifiant est construit à partir de l'initiale du prénom et du nom de famille, suivi des actions avec ces initiales.
-- **Gestion du parc de chauffeurs** : ajout/suppression de chauffeurs depuis l'administration, sélection rapide dans les formulaires de création de course.
+- **Comptes administrateurs** : session sécurisée par jeton, rôles `superadmin`, `manager` ou `standard` avec contrôle fin des droits et historique des actions signées par les initiales.
+- **Gestion du parc de chauffeurs** : ajout/suppression de chauffeurs et pilotage de leurs mots de passe depuis un panneau dédié aux administrateurs.
 - **Archivage avancé** : onglet dédié pour consulter les courses archivées avec filtres par chauffeur, période et type de marchandise, archivage/désarchivage directement depuis le journal d'activité.
 - **Gestion complète des courses** : création, édition, suppression et validation avec prise de photo du bon de transport.
-- **Notifications par e-mail** : envoi automatique via l'API Gmail avec pièce jointe lors de la validation d'une course.
+- **Notifications par e-mail** : envoi automatique via l'API Gmail avec pièce jointe lors de la validation d'une course et adresse de réception administrable depuis les paramètres.
 - **Persistance des données** : stockage des chauffeurs, courses, journaux d'activité et e-mails simulés dans une base SQLite embarquée.
 
 ## Démarrage rapide
@@ -69,13 +69,11 @@ npm run create-gmail-token -- --refresh-token="1//0gXXXXXXXXXXXXXXXXXXXX" --outp
 Ces fichiers peuvent être générés à l'aide du script de test Gmail fourni et permettent de conserver
 le dossier `assets/images` vide tout en référencant l'image `login.png` pour l'écran de connexion.
 
-L'onglet « Paramètres » de l'administration permet de piloter toute la configuration e-mail :
-
-- adresse de réception utilisée lors de la validation d'une course ;
-- `client_id`, `client_secret`, `refresh_token` et `redirect_uri` Gmail à renseigner tels qu'affichés dans la console Google Cloud.
-
-Les valeurs saisies sont stockées en base SQLite. Elles sont rechargées à chaque envoi d'e-mail et servent de secours si aucune
-variable d'environnement n'est définie. Les variables d'environnement restent prioritaires si elles sont présentes.
+L'onglet « Paramètres » de l'administration propose un onglet « Configuration email » qui permet aux administrateurs
+connectés de modifier l'adresse de réception des comptes rendus. Les identifiants OAuth (client, secret,
+refresh token, redirect URI) restent pilotés par les variables d'environnement ou par les fichiers `credentials.json`
+et `token.json` présents à la racine du projet. Lorsqu'ils sont enregistrés en base via l'API, ils servent de valeur
+de secours mais ne sont pas éditables dans l'interface.
 
 ### Structure des données
 
@@ -83,10 +81,12 @@ La base SQLite est initialisée automatiquement au démarrage dans le dossier `d
 
 ### Accès administrateur
 
-- Lors de la connexion, cliquez sur « Connexion administration » puis saisissez votre identifiant : initiale du prénom suivie du nom en minuscules (ex. `lsaquet`).
-- Un mot de passe est requis pour accéder à l'espace d'administration. Le compte de démonstration créé automatiquement utilise le mot de passe `admin` (modifiable via la variable d'environnement `ADMIN_DEFAULT_PASSWORD`).
-- Il est possible de créer un nouveau compte directement depuis cette fenêtre en renseignant un prénom et un nom. L'application génère automatiquement l'identifiant associé et vous invite à définir un mot de passe (aucune contrainte particulière).
-- Toutes les actions menées depuis l'administration (création, édition, archivage, suppression) sont historisées dans le journal avec les initiales de l'administrateur connecté.
+- Cliquez sur « Connexion administration » puis saisissez votre identifiant : initiale du prénom suivie du nom en minuscules (ex. `lsaquet`).
+- Un compte super administrateur « Laurent Saquet » est automatiquement créé au démarrage avec l'identifiant `lsaquet` et le mot de passe par défaut `lannion` (surchageable via `SUPER_ADMIN_DEFAULT_PASSWORD`).
+- Seul ce super administrateur peut créer ou supprimer d'autres comptes administrateurs depuis l'onglet **Paramètres → Administrateurs** et attribuer un rôle (`manager` ou `standard`).
+- Chaque administrateur peut modifier son propre mot de passe dans l'onglet **Paramètres → Administrateurs** après saisie du mot de passe actuel.
+- L'onglet **Paramètres → Accès chauffeurs** permet d'ajouter, modifier ou retirer les mots de passe des chauffeurs ; ils deviennent obligatoires à la connexion lorsqu'ils sont définis.
+- Toutes les actions menées depuis l'administration (création, modification, archivage, suppression, gestion des comptes) sont historisées dans le journal avec les initiales de l'administrateur connecté.
 
 ## Scripts complémentaires
 
@@ -101,20 +101,29 @@ La base SQLite est initialisée automatiquement au démarrage dans le dossier `d
 | Méthode | Chemin | Description |
 | --- | --- | --- |
 | `GET /api/drivers` | Liste les chauffeurs (filtrage via `?search=`). |
-| `POST /api/drivers` | Ajoute un chauffeur. |
-| `DELETE /api/drivers/:id` | Supprime un chauffeur et ses courses associées. |
-| `GET /api/admins` | Liste les comptes administrateurs existants. |
-| `POST /api/admins` | Crée un compte administrateur à partir d'un prénom et d'un nom. |
-| `POST /api/admins/login` | Connecte un administrateur via son identifiant généré. |
+| `POST /api/drivers` | Ajoute un chauffeur (requiert l'en-tête `X-Admin-Token`). |
+| `DELETE /api/drivers/:id` | Supprime un chauffeur et ses courses associées (requiert `X-Admin-Token`). |
+| `GET /api/drivers/credentials` | Retourne la liste des chauffeurs et l'état de leurs mots de passe (requiert `X-Admin-Token`). |
+| `PUT /api/drivers/:id/password` | Définit ou met à jour le mot de passe d'un chauffeur (requiert `X-Admin-Token`). |
+| `DELETE /api/drivers/:id/password` | Supprime le mot de passe d'un chauffeur (requiert `X-Admin-Token`). |
+| `POST /api/drivers/login` | Valide l'accès chauffeur et vérifie le mot de passe lorsqu'il est défini. |
+| `GET /api/admins` | Liste les comptes administrateurs existants (données minimales pour l'écran de connexion). |
+| `POST /api/admins` | Crée un compte administrateur (réservé au super administrateur via `X-Admin-Token`). |
+| `DELETE /api/admins/:id` | Supprime un compte administrateur (réservé au super administrateur via `X-Admin-Token`). |
+| `POST /api/admins/login` | Connecte un administrateur et retourne un jeton de session. |
+| `POST /api/admins/logout` | Ferme la session administrateur active (requiert `X-Admin-Token`). |
+| `PUT /api/admins/:id/password` | Met à jour le mot de passe de l'administrateur connecté (requiert `X-Admin-Token`). |
 | `GET /api/courses` | Liste les courses avec filtres `driverId`, `from`, `to`, `archived`. |
 | `GET /api/courses/:id` | Récupère le détail d'une course. |
 | `POST /api/courses` | Crée une nouvelle course. |
 | `PUT /api/courses/:id` | Met à jour une course existante. |
-| `DELETE /api/courses/:id` | Supprime une course. |
+| `DELETE /api/courses/:id` | Supprime une course et journalise l'opération. |
 | `POST /api/courses/:id/complete` | Valide une course, sauvegarde la photo et journalise l'activité. |
 | `POST /api/courses/:id/archive` | Archive une course active. |
 | `POST /api/courses/:id/unarchive` | Restaure une course archivée. |
 | `GET /api/activity` | Retourne le journal des actions sur les courses. |
+| `GET /api/settings/email-recipient` | Retourne l'adresse email de réception (requiert `X-Admin-Token`). |
+| `PUT /api/settings/email-recipient` | Met à jour l'adresse email de réception (requiert `X-Admin-Token`). |
 | `GET /api/emails` | Liste les e-mails simulés envoyés lors des validations. |
 
 ## Développement futur

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ npm run create-gmail-token -- --refresh-token="1//0gXXXXXXXXXXXXXXXXXXXX" --outp
 Ces fichiers peuvent être générés à l'aide du script de test Gmail fourni et permettent de conserver
 le dossier `assets/images` vide tout en référencant l'image `login.png` pour l'écran de connexion.
 
-Le destinataire peut ensuite être modifié directement depuis l'onglet « Paramètres » de l'administration.
+L'onglet « Paramètres » de l'administration permet de piloter toute la configuration e-mail :
+
+- adresse de réception utilisée lors de la validation d'une course ;
+- `client_id`, `client_secret`, `refresh_token` et `redirect_uri` Gmail à renseigner tels qu'affichés dans la console Google Cloud.
+
+Les valeurs saisies sont stockées en base SQLite. Elles sont rechargées à chaque envoi d'e-mail et servent de secours si aucune
+variable d'environnement n'est définie. Les variables d'environnement restent prioritaires si elles sont présentes.
 
 ### Structure des données
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ L'application utilise l'API Gmail en OAuth2. Avant de lancer le serveur, défini
 | `GMAIL_SENDER` | Adresse e-mail expéditrice (défaut : `chauffeur.agriholann@gmail.com`). |
 | `DEFAULT_COMPLETION_EMAIL` | Adresse de réception par défaut des comptes rendus de courses. |
 
+À défaut de variables d'environnement, le serveur tente automatiquement de charger les identifiants
+depuis des fichiers placés à la racine du projet :
+
+- `credentials.json` contenant la configuration OAuth (clé `web` ou `installed`).
+- `token.json` contenant un champ `refresh_token` valide.
+
+Ces fichiers peuvent être générés à l'aide du script de test Gmail fourni et permettent de conserver
+le dossier `assets/images` vide tout en référencant l'image `login.png` pour l'écran de connexion.
+
 Le destinataire peut ensuite être modifié directement depuis l'onglet « Paramètres » de l'administration.
 
 ### Structure des données

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ depuis des fichiers placés à la racine du projet :
 - `credentials.json` contenant la configuration OAuth (clé `web` ou `installed`).
 - `token.json` contenant un champ `refresh_token` valide.
 
+Vous pouvez générer ce fichier `token.json` automatiquement à partir d'un refresh token existant :
+
+```bash
+# Exemple avec le refresh_token récupéré via votre script get_refresh_token.js
+npm run create-gmail-token -- --refresh-token="1//0gXXXXXXXXXXXXXXXXXXXX"
+
+# Pour choisir un autre emplacement ou écraser un fichier existant
+npm run create-gmail-token -- --refresh-token="1//0gXXXXXXXXXXXXXXXXXXXX" --output=/chemin/vers/token.json --force
+```
+
 Ces fichiers peuvent être générés à l'aide du script de test Gmail fourni et permettent de conserver
 le dossier `assets/images` vide tout en référencant l'image `login.png` pour l'écran de connexion.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Application web permettant à l'entreprise Agri Holann de planifier les tournée
 - **Archivage avancé** : onglet dédié pour consulter les courses archivées avec filtres par chauffeur, période et type de marchandise, archivage/désarchivage directement depuis le journal d'activité.
 - **Gestion complète des courses** : création, édition, suppression et validation avec prise de photo du bon de transport.
 - **Notifications par e-mail** : envoi automatique via l'API Gmail avec pièce jointe lors de la validation d'une course et adresse de réception administrable depuis les paramètres.
+- **Signalement d'incident** : un chauffeur peut marquer une course comme « en attente » en décrivant le problème rencontré ; l'administration est immédiatement notifiée et un e-mail d'alerte est expédié.
+- **Messagerie sécurisée et instantanée** : bouton flottant toujours visible permettant aux chauffeurs et administrateurs d'échanger en temps réel, avec notifications des nouveaux messages et historique par chauffeur.
 - **Persistance des données** : stockage des chauffeurs, courses, journaux d'activité et e-mails simulés dans une base SQLite embarquée.
 
 ## Démarrage rapide
@@ -77,7 +79,7 @@ de secours mais ne sont pas éditables dans l'interface.
 
 ### Structure des données
 
-La base SQLite est initialisée automatiquement au démarrage dans le dossier `db/agriholann.db` avec des données de démonstration (chauffeurs et courses). Les photos prises lors des validations ainsi que les pièces jointes des e-mails simulés sont stockées dans `storage/attachments`.
+La base SQLite principale est initialisée automatiquement au démarrage dans le dossier `db/agriholann.db` avec des données de démonstration (chauffeurs et courses). Une base dédiée `db/agriholann-messages.db` enregistre l'historique de la messagerie sécurisée. Les photos prises lors des validations ainsi que les pièces jointes des e-mails simulés sont stockées dans `storage/attachments`.
 
 ### Accès administrateur
 
@@ -119,12 +121,18 @@ La base SQLite est initialisée automatiquement au démarrage dans le dossier `d
 | `PUT /api/courses/:id` | Met à jour une course existante. |
 | `DELETE /api/courses/:id` | Supprime une course et journalise l'opération. |
 | `POST /api/courses/:id/complete` | Valide une course, sauvegarde la photo et journalise l'activité. |
+| `POST /api/courses/:id/report-issue` | Signale un problème sur une course (chauffeur) et notifie l'administration. |
 | `POST /api/courses/:id/archive` | Archive une course active. |
 | `POST /api/courses/:id/unarchive` | Restaure une course archivée. |
 | `GET /api/activity` | Retourne le journal des actions sur les courses. |
 | `GET /api/settings/email-recipient` | Retourne l'adresse email de réception (requiert `X-Admin-Token`). |
 | `PUT /api/settings/email-recipient` | Met à jour l'adresse email de réception (requiert `X-Admin-Token`). |
 | `GET /api/emails` | Liste les e-mails simulés envoyés lors des validations. |
+| `GET /api/messages/unread-count` | Retourne le nombre de messages non lus pour l'utilisateur connecté. |
+| `GET /api/messages/inbox` | Liste les conversations actives (administration). |
+| `GET /api/messages/threads/:driverId` | Récupère l'historique d'échanges avec un chauffeur. |
+| `POST /api/messages` | Envoie un message dans la messagerie sécurisée. |
+| `POST /api/messages/:driverId/read` | Marque les messages d'une conversation comme lus. |
 
 ## Développement futur
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Application web permettant à l'entreprise Agri Holann de planifier les tournée
 - **Gestion du parc de chauffeurs** : ajout/suppression de chauffeurs depuis l'administration, sélection rapide dans les formulaires de création de course.
 - **Archivage avancé** : onglet dédié pour consulter les courses archivées avec filtres par chauffeur, période et type de marchandise, archivage/désarchivage directement depuis le journal d'activité.
 - **Gestion complète des courses** : création, édition, suppression et validation avec prise de photo du bon de transport.
-- **Notifications par e-mail** : envoi automatique (transport simulé) d'un récapitulatif au siège lors de la validation d'une course.
+- **Notifications par e-mail** : envoi automatique via l'API Gmail avec pièce jointe lors de la validation d'une course.
 - **Persistance des données** : stockage des chauffeurs, courses, journaux d'activité et e-mails simulés dans une base SQLite embarquée.
 
 ## Démarrage rapide
@@ -33,6 +33,21 @@ npm start
 ```
 
 Le serveur écoute par défaut sur [http://localhost:3000](http://localhost:3000) et sert à la fois l'API et l'interface web.
+
+### Configuration de l'envoi d'e-mails
+
+L'application utilise l'API Gmail en OAuth2. Avant de lancer le serveur, définissez les variables d'environnement suivantes :
+
+| Variable | Description |
+| --- | --- |
+| `GMAIL_CLIENT_ID` | Identifiant OAuth2 de l'application Google Cloud. |
+| `GMAIL_CLIENT_SECRET` | Secret OAuth2 associé. |
+| `GMAIL_REFRESH_TOKEN` | Jeton d'actualisation autorisant l'envoi au nom du compte Gmail. |
+| `GMAIL_REDIRECT_URI` | URI de redirection utilisé lors de la génération du jeton (défaut : `http://localhost`). |
+| `GMAIL_SENDER` | Adresse e-mail expéditrice (défaut : `chauffeur.agriholann@gmail.com`). |
+| `DEFAULT_COMPLETION_EMAIL` | Adresse de réception par défaut des comptes rendus de courses. |
+
+Le destinataire peut ensuite être modifié directement depuis l'onglet « Paramètres » de l'administration.
 
 ### Structure des données
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,13 @@ L'application utilise l'API Gmail en OAuth2. Avant de lancer le serveur, défini
 | `DEFAULT_COMPLETION_EMAIL` | Adresse de réception par défaut des comptes rendus de courses. |
 
 À défaut de variables d'environnement, le serveur tente automatiquement de charger les identifiants
-depuis des fichiers placés à la racine du projet :
+depuis des fichiers placés à la racine du projet (dans le même dossier que `server.js`) :
 
-- `credentials.json` contenant la configuration OAuth (clé `web` ou `installed`).
-- `token.json` contenant un champ `refresh_token` valide.
+- `credentials.json` contenant la configuration OAuth (clé `web` ou `installed`, champs `client_id`, `client_secret` et `redirect_uris` ou `redirect_uri`).
+- `token.json` contenant un champ `refresh_token` (le format `refreshToken` est également accepté).
+
+Les fichiers sont relus à chaque tentative d'envoi : vous pouvez donc les ajouter ou les remplacer sans
+redémarrer l'application, l'API Gmail sera automatiquement reconfigurée.
 
 Vous pouvez générer ce fichier `token.json` automatiquement à partir d'un refresh token existant :
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -347,6 +347,93 @@
   color: #fff;
 }
 
+.today-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.course-item--list {
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.course-item--list:hover {
+  background-color: rgb(249, 250, 251);
+}
+
+#driver-dashboard[data-course-layout='list'] .course-item--list .issue-toggle {
+  align-self: flex-start;
+}
+
+#driver-dashboard[data-course-density='contrast'] .course-item {
+  border-color: rgba(17, 24, 39, 0.6);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+}
+
+#driver-dashboard[data-course-density='contrast'] .course-item .text-gray-500 {
+  color: rgb(55, 65, 81);
+}
+
+#driver-dashboard[data-course-density='contrast'] .course-item .text-gray-600 {
+  color: rgb(31, 41, 55);
+  font-weight: 500;
+}
+
+.driver-week-row {
+  transition: background-color 0.2s ease;
+}
+
+#driver-dashboard[data-course-density='contrast'] .driver-week-row td {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  font-size: 0.95rem;
+  color: rgb(17, 24, 39);
+}
+
+.admin-course-card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-course-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.15);
+}
+
+.admin-course-card--with-comments {
+  background-color: rgb(239, 246, 255);
+  border-color: rgb(191, 219, 254);
+}
+
+.admin-course-card button {
+  transition: transform 0.2s ease;
+}
+
+.admin-course-card button:hover {
+  transform: translateY(-1px);
+}
+
+#admin-dashboard[data-course-density='contrast'] .admin-course-card {
+  border-color: rgba(15, 23, 42, 0.6);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
+}
+
+#admin-dashboard[data-course-density='contrast'] .admin-course-card .text-gray-500,
+#admin-dashboard[data-course-density='contrast'] .admin-course-card .text-gray-700 {
+  color: rgb(17, 24, 39);
+  font-weight: 600;
+}
+
+.admin-course-row {
+  transition: background-color 0.2s ease;
+}
+
+#admin-dashboard[data-course-density='contrast'] .admin-course-row td {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  font-size: 0.95rem;
+  color: rgb(17, 24, 39);
+}
+
 .messaging-fab {
   position: fixed;
   bottom: 1.5rem;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2,6 +2,13 @@
   animation: fadeIn 0.3s ease-in-out;
 }
 
+#login-page {
+  background-image: url('../images/login.png');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -303,6 +303,29 @@
   background-color: rgb(219, 234, 254);
 }
 
+.admin-management-tab {
+  padding: 0.45rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgb(75, 85, 99);
+  background-color: transparent;
+  border: 1px solid transparent;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.admin-management-tab:hover {
+  color: rgb(37, 99, 235);
+  background-color: rgb(243, 244, 246);
+}
+
+.admin-management-tab--active {
+  color: rgb(37, 99, 235);
+  background-color: rgb(219, 234, 254);
+  border-color: rgb(191, 219, 254);
+}
+
 .filter-chip {
   display: inline-flex;
   align-items: center;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -283,6 +283,26 @@
   border-bottom-color: rgb(37, 99, 235);
 }
 
+.settings-tab {
+  padding: 0.5rem 1rem;
+  font-weight: 500;
+  color: rgb(75, 85, 99);
+  border-bottom: 2px solid transparent;
+  border-radius: 0.5rem 0.5rem 0 0;
+  transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.settings-tab:hover {
+  color: rgb(37, 99, 235);
+  background-color: rgb(243, 244, 246);
+}
+
+.settings-tab--active {
+  color: rgb(37, 99, 235);
+  border-bottom-color: rgb(37, 99, 235);
+  background-color: rgb(219, 234, 254);
+}
+
 .filter-chip {
   display: inline-flex;
   align-items: center;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -346,3 +346,329 @@
   border-color: rgb(37, 99, 235);
   color: #fff;
 }
+
+.messaging-fab {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 60;
+}
+
+.messaging-fab__button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #16a34a, #22c55e);
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(22, 163, 74, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.messaging-fab__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 35px rgba(22, 163, 74, 0.45);
+}
+
+.messaging-fab__badge {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  min-width: 1.5rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 9999px;
+  background-color: rgb(239, 68, 68);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.messaging-panel {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.35);
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 1.5rem;
+  z-index: 55;
+}
+
+.messaging-panel__container {
+  width: 100%;
+  max-width: 28rem;
+  background-color: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: min(80vh, 32rem);
+}
+
+.messaging-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.08), rgba(59, 130, 246, 0.05));
+}
+
+.messaging-panel__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgb(15, 23, 42);
+}
+
+.messaging-panel__subtitle {
+  font-size: 0.85rem;
+  color: rgb(100, 116, 139);
+}
+
+.messaging-panel__select {
+  display: inline-flex;
+  padding: 0.4rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid rgb(226, 232, 240);
+  font-size: 0.85rem;
+  color: rgb(71, 85, 105);
+  background-color: #fff;
+}
+
+.messaging-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  background-color: rgba(15, 23, 42, 0.05);
+  color: rgb(71, 85, 105);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.messaging-panel__close:hover {
+  background-color: rgba(15, 23, 42, 0.1);
+  color: rgb(15, 23, 42);
+}
+
+.messaging-panel__body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.messaging-thread-list {
+  width: 12rem;
+  border-right: 1px solid rgba(226, 232, 240, 0.8);
+  background-color: rgba(248, 250, 252, 0.8);
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.messaging-thread {
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.messaging-thread:hover {
+  background-color: rgba(34, 197, 94, 0.1);
+  transform: translateY(-1px);
+}
+
+.messaging-thread__name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgb(30, 41, 59);
+}
+
+.messaging-thread__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  color: rgb(100, 116, 139);
+}
+
+.messaging-thread--active {
+  background-color: rgba(16, 185, 129, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.35);
+}
+
+.messaging-thread__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  background-color: rgb(239, 68, 68);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0 0.4rem;
+}
+
+.messaging-conversation {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.messaging-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background-color: rgba(248, 250, 252, 0.6);
+}
+
+.messaging-message {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.messaging-message__avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  background-color: rgba(59, 130, 246, 0.15);
+  color: rgb(37, 99, 235);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.messaging-message__bubble {
+  max-width: 80%;
+  background-color: #fff;
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.messaging-message__bubble strong {
+  display: block;
+  font-size: 0.78rem;
+  margin-bottom: 0.25rem;
+  color: rgb(71, 85, 105);
+}
+
+.messaging-message__meta {
+  margin-top: 0.35rem;
+  font-size: 0.7rem;
+  color: rgb(148, 163, 184);
+}
+
+.messaging-message--mine {
+  flex-direction: row-reverse;
+}
+
+.messaging-message--mine .messaging-message__avatar {
+  background-color: rgba(34, 197, 94, 0.15);
+  color: rgb(22, 163, 74);
+}
+
+.messaging-message--mine .messaging-message__bubble {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.95), rgba(16, 185, 129, 0.9));
+  color: #fff;
+  border-color: rgba(16, 185, 129, 0.1);
+}
+
+.messaging-form {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid rgba(226, 232, 240, 0.9);
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.messaging-input {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(203, 213, 225, 0.9);
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  resize: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.messaging-input:focus {
+  outline: none;
+  border-color: rgba(34, 197, 94, 0.85);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.25);
+}
+
+.messaging-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.messaging-error {
+  font-size: 0.8rem;
+  color: rgb(239, 68, 68);
+}
+
+.messaging-send {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 1.2rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #16a34a, #22c55e);
+  color: #fff;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.messaging-send:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(22, 163, 74, 0.35);
+}
+
+@media (max-width: 768px) {
+  .messaging-panel {
+    padding: 0.75rem;
+    align-items: stretch;
+  }
+
+  .messaging-panel__container {
+    max-width: none;
+    border-radius: 1rem 1rem 0 0;
+    max-height: 90vh;
+  }
+
+  .messaging-panel__body {
+    flex-direction: column;
+  }
+
+  .messaging-thread-list {
+    width: 100%;
+    display: flex;
+    gap: 0.75rem;
+    overflow-x: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  }
+
+  .messaging-conversation {
+    flex: 1;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,7 @@ const state = {
   pendingCompletionComments: '',
   pendingDriverLogin: null,
   driverPasswordError: '',
+  activeDriverTab: 'today',
   driverManagement: {
     expanded: false,
     loading: false,
@@ -164,6 +165,8 @@ const elements = {
   adminPasswordNew: document.getElementById('admin-password-new'),
   adminPasswordFeedback: document.getElementById('admin-password-feedback'),
 };
+
+let eventSource = null;
 
 function showElement(element) {
   if (element) {
@@ -372,7 +375,7 @@ function renderDriverList(drivers) {
 }
 
 async function loginAsDriver(driver, options = {}) {
-  const { skipPasswordCheck = false } = options;
+  const { skipPasswordCheck = false, initialTab = 'today' } = options;
   const normalizedDriver = normalizeDriver(driver);
 
   if (!skipPasswordCheck && normalizedDriver.hasPassword) {
@@ -393,8 +396,10 @@ async function loginAsDriver(driver, options = {}) {
   showElement(elements.driverDashboard);
   hideElement(elements.adminDashboard);
   closeDriverPasswordModal();
-  switchTab('today');
+  state.activeDriverTab = initialTab;
+  switchTab(initialTab);
   await loadDriverCourses();
+  persistSessionState();
 }
 
 function openDriverPasswordModal(driver) {
@@ -495,22 +500,28 @@ async function handleDriverPasswordPrompt(password) {
   await processDriverPassword(password, { inline: false });
 }
 
-function setAdminSession(admin) {
+function setAdminSession(admin, options = {}) {
   const normalized = normalizeAdmin(admin);
+  const defaultAdminFilters = { driverId: 'all', range: 'week' };
+  const defaultArchiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
+  const view = options.view || options.adminView || 'planning';
+  const driverTab = options.driverTab || options.activeDriverTab || 'week';
+  const settingsTab = options.settingsTab || 'email';
+
   state.currentUser = {
     ...normalized,
     role: 'admin',
     adminLevel: normalized.role || 'standard',
-    token: admin.token || null,
+    token: admin.token || state.currentUser?.token || null,
   };
   state.isAdmin = true;
-  state.adminFilters = { driverId: 'all', range: 'week' };
-  state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
+  state.adminFilters = { ...defaultAdminFilters, ...(options.adminFilters || {}) };
+  state.archiveFilters = { ...defaultArchiveFilters, ...(options.archiveFilters || {}) };
   state.settings = {
     emailRecipient: '',
     loaded: false,
     saving: false,
-    activeTab: 'email',
+    activeTab: settingsTab,
   };
   state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
   state.driverManagement.expanded = false;
@@ -518,7 +529,7 @@ function setAdminSession(admin) {
   state.driverManagement.error = null;
   state.adminDrivers = [];
   state.driverSearchResults = [];
-  updateArchivePeriodInputs();
+  state.activeDriverTab = driverTab;
 
   hideElement(elements.loginPage);
   hideElement(elements.driverDashboard);
@@ -539,10 +550,25 @@ function setAdminSession(admin) {
   renderDriverManagementPanel();
   renderSettingsTabs();
 
-  state.adminView = 'planning';
-  switchAdminView('planning');
+  switchAdminView(view);
   updateAdminRangeButtons();
-  switchTab('week');
+  switchTab(state.activeDriverTab);
+
+  if (elements.archiveMerchandiseFilter) {
+    elements.archiveMerchandiseFilter.value = state.archiveFilters.merchandise || 'all';
+  }
+  if (elements.archivePeriodFilter) {
+    elements.archivePeriodFilter.value = state.archiveFilters.period || 'week';
+  }
+  updateArchivePeriodInputs({ resetValues: false });
+  if (state.archiveFilters.period === 'custom') {
+    if (elements.archiveFromInput) {
+      elements.archiveFromInput.value = state.archiveFilters.from || '';
+    }
+    if (elements.archiveToInput) {
+      elements.archiveToInput.value = state.archiveFilters.to || '';
+    }
+  }
 
   loadAdminDrivers();
   loadAdminCourses();
@@ -552,6 +578,7 @@ function setAdminSession(admin) {
   if (state.currentUser.adminLevel === 'superadmin') {
     loadAdmins();
   }
+  persistSessionState();
 }
 
 function openAdminLoginModal() {
@@ -749,6 +776,7 @@ async function logout(event) {
   state.driverCourses = [];
   state.adminCourses = [];
   state.archivedCourses = [];
+  state.activeDriverTab = 'today';
   state.adminFilters = { driverId: 'all', range: 'week' };
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
   state.settings = {
@@ -808,9 +836,11 @@ async function logout(event) {
   updateArchivePeriodInputs();
   showElement(elements.loginPage);
   switchTab('today');
+  clearPersistedSession();
 }
 
 function switchTab(tab) {
+  state.activeDriverTab = tab;
   const tabs = [elements.todayTab, elements.weekTab, elements.newCourseTab];
   tabs.forEach((tabElement) => {
     tabElement.classList.remove('tab-button--active');
@@ -836,6 +866,10 @@ function switchTab(tab) {
     elements.newCourseTab.classList.remove('text-gray-500');
     showElement(elements.newCourseForm);
     elements.adminDriverField.classList.toggle('hidden', !state.isAdmin);
+  }
+
+  if (state.currentUser) {
+    persistSessionState();
   }
 }
 
@@ -876,6 +910,10 @@ function switchAdminView(view) {
 
   if (view === 'settings') {
     ensureSettingsData();
+  }
+
+  if (state.currentUser?.role === 'admin') {
+    persistSessionState();
   }
 }
 
@@ -971,6 +1009,9 @@ function setSettingsTab(tab) {
   if (state.settings.activeTab !== tab) {
     state.settings.activeTab = tab;
     renderSettingsTabs();
+    if (state.currentUser?.role === 'admin') {
+      persistSessionState();
+    }
   }
 
   ensureSettingsData(tab);
@@ -1359,7 +1400,8 @@ function renderArchivedCourses() {
     });
 }
 
-function updateArchivePeriodInputs() {
+function updateArchivePeriodInputs(options = {}) {
+  const { resetValues = true } = options;
   if (!elements.archiveFromInput || !elements.archiveToInput) {
     return;
   }
@@ -1371,8 +1413,13 @@ function updateArchivePeriodInputs() {
   if (!isCustom) {
     elements.archiveFromInput.value = '';
     elements.archiveToInput.value = '';
-    state.archiveFilters.from = null;
-    state.archiveFilters.to = null;
+    if (resetValues) {
+      state.archiveFilters.from = null;
+      state.archiveFilters.to = null;
+    }
+  } else {
+    elements.archiveFromInput.value = state.archiveFilters.from || '';
+    elements.archiveToInput.value = state.archiveFilters.to || '';
   }
 }
 
@@ -1383,6 +1430,9 @@ function handleArchivePeriodChange() {
   state.archiveFilters.period = elements.archivePeriodFilter.value || 'week';
   updateArchivePeriodInputs();
   loadArchivedCourses();
+  if (state.currentUser?.role === 'admin') {
+    persistSessionState();
+  }
 }
 
 function handleArchiveFiltersChange() {
@@ -1393,6 +1443,9 @@ function handleArchiveFiltersChange() {
     state.archiveFilters.merchandise = elements.archiveMerchandiseFilter.value || 'all';
   }
   loadArchivedCourses();
+  if (state.currentUser?.role === 'admin') {
+    persistSessionState();
+  }
 }
 
 function handleArchiveDatesChange() {
@@ -1402,6 +1455,9 @@ function handleArchiveDatesChange() {
   state.archiveFilters.from = elements.archiveFromInput.value || null;
   state.archiveFilters.to = elements.archiveToInput.value || null;
   loadArchivedCourses();
+  if (state.currentUser?.role === 'admin') {
+    persistSessionState();
+  }
 }
 
 function resetEmailSettingsStatus() {
@@ -2446,6 +2502,224 @@ async function confirmPhoto() {
   }
 }
 
+function clearPersistedSession() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.removeItem('agriHolannSession');
+  } catch (error) {
+    console.warn('Impossible de supprimer la session enregistrée', error);
+  }
+}
+
+function persistSessionState() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  if (!state.currentUser) {
+    clearPersistedSession();
+    return;
+  }
+
+  const session = {
+    role: state.currentUser.role,
+    activeDriverTab: state.activeDriverTab || 'today',
+  };
+
+  if (state.currentUser.role === 'driver') {
+    session.user = {
+      id: state.currentUser.id,
+      firstName: state.currentUser.firstName,
+      lastName: state.currentUser.lastName,
+      hasPassword: state.currentUser.hasPassword || false,
+    };
+  } else if (state.currentUser.role === 'admin') {
+    session.user = {
+      id: state.currentUser.id,
+      firstName: state.currentUser.firstName,
+      lastName: state.currentUser.lastName,
+      identifier: state.currentUser.identifier,
+      initials: state.currentUser.initials,
+      adminLevel: state.currentUser.adminLevel,
+    };
+    session.token = state.currentUser.token || null;
+    session.adminView = state.adminView;
+    session.settingsTab = state.settings?.activeTab || 'email';
+    session.adminFilters = { ...state.adminFilters };
+    session.archiveFilters = { ...state.archiveFilters };
+  }
+
+  try {
+    window.localStorage.setItem('agriHolannSession', JSON.stringify(session));
+  } catch (error) {
+    console.warn('Impossible de sauvegarder la session', error);
+  }
+}
+
+function handleRealtimeEvent(event) {
+  if (!event || !event.type) {
+    return;
+  }
+
+  const payload = event.payload || {};
+
+  switch (event.type) {
+    case 'drivers:updated':
+      if (state.isAdmin) {
+        loadAdminDrivers({ force: true });
+        loadDriverCredentials();
+      }
+      if (state.currentUser?.role === 'driver') {
+        if (!payload.driverId || payload.driverId === state.currentUser.id) {
+          loadDriverCourses();
+        }
+      }
+      break;
+    case 'driver-passwords:updated':
+      if (state.isAdmin) {
+        loadDriverCredentials();
+      }
+      if (state.currentUser?.role === 'driver') {
+        if (!payload.driverId || payload.driverId === state.currentUser.id) {
+          loadDriverCourses();
+        }
+      }
+      break;
+    case 'courses:changed':
+      if (state.currentUser?.role === 'driver') {
+        if (!payload.driverId || payload.driverId === state.currentUser.id) {
+          loadDriverCourses();
+        }
+      }
+      if (state.isAdmin) {
+        loadAdminCourses();
+        loadArchivedCourses();
+        loadActivityLog();
+      }
+      break;
+    case 'activity:changed':
+      if (state.isAdmin) {
+        loadActivityLog();
+      }
+      break;
+    case 'admins:updated':
+      if (state.isAdmin && state.currentUser?.adminLevel === 'superadmin') {
+        loadAdmins();
+      }
+      break;
+    case 'settings:email-updated':
+      if (state.isAdmin) {
+        loadEmailRecipient();
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+function setupRealtimeUpdates() {
+  if (typeof window === 'undefined' || !window.EventSource) {
+    console.warn("Les mises à jour en direct ne sont pas supportées par ce navigateur.");
+    return;
+  }
+
+  if (eventSource) {
+    eventSource.close();
+  }
+
+  eventSource = new EventSource(`${API_BASE}/events`);
+
+  eventSource.onmessage = (message) => {
+    if (!message?.data) {
+      return;
+    }
+    try {
+      const event = JSON.parse(message.data);
+      handleRealtimeEvent(event);
+    } catch (error) {
+      console.warn('Impossible de décoder un événement en temps réel', error);
+    }
+  };
+
+  eventSource.onerror = (error) => {
+    console.warn('Connexion temps réel interrompue, nouvelle tentative automatique...', error);
+  };
+}
+
+async function restoreSessionFromStorage() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    showElement(elements.loginPage);
+    return;
+  }
+
+  const raw = window.localStorage.getItem('agriHolannSession');
+  if (!raw) {
+    showElement(elements.loginPage);
+    return;
+  }
+
+  let saved;
+  try {
+    saved = JSON.parse(raw);
+  } catch (error) {
+    console.warn('Session locale invalide, purge.', error);
+    clearPersistedSession();
+    showElement(elements.loginPage);
+    return;
+  }
+
+  if (saved.role === 'admin' && saved.token) {
+    try {
+      const response = await fetch(`${API_BASE}/admins/session`, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': saved.token,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Session administrateur invalide');
+      }
+
+      const admin = await response.json();
+      setAdminSession(admin, {
+        view: saved.adminView || 'planning',
+        driverTab: saved.activeDriverTab || 'week',
+        settingsTab: saved.settingsTab || 'email',
+        adminFilters: saved.adminFilters || {},
+        archiveFilters: saved.archiveFilters || {},
+      });
+      return;
+    } catch (error) {
+      console.warn('Impossible de restaurer la session administrateur', error);
+      clearPersistedSession();
+      showElement(elements.loginPage);
+      return;
+    }
+  }
+
+  if (saved.role === 'driver' && saved.user?.id) {
+    try {
+      const driver = await apiFetch(`/drivers/${saved.user.id}`);
+      await loginAsDriver(driver, {
+        skipPasswordCheck: true,
+        initialTab: saved.activeDriverTab || 'today',
+      });
+      return;
+    } catch (error) {
+      console.warn('Impossible de restaurer la session chauffeur', error);
+      clearPersistedSession();
+      showElement(elements.loginPage);
+      return;
+    }
+  }
+
+  clearPersistedSession();
+  showElement(elements.loginPage);
+}
+
 function registerEventListeners() {
   elements.lastnameInput.addEventListener('input', searchDrivers);
   elements.adminLoginBtn.addEventListener('click', openAdminLoginModal);
@@ -2480,6 +2754,9 @@ function registerEventListeners() {
     if (state.isAdmin) {
       loadAdminCourses();
     }
+    if (state.currentUser?.role === 'admin') {
+      persistSessionState();
+    }
   });
   elements.newCourseAdminBtn.addEventListener('click', () => {
     openCourseEditor();
@@ -2495,6 +2772,9 @@ function registerEventListeners() {
         state.adminFilters.range = range || 'week';
         updateAdminRangeButtons();
         loadAdminCourses();
+        if (state.currentUser?.role === 'admin') {
+          persistSessionState();
+        }
       });
     });
   }
@@ -2561,6 +2841,14 @@ function init() {
   renderDriverManagementPanel();
   renderSettingsTabs();
   registerEventListeners();
+  setupRealtimeUpdates();
+  restoreSessionFromStorage();
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+window.addEventListener('beforeunload', () => {
+  if (eventSource) {
+    eventSource.close();
+  }
+});

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,5 @@
 const API_BASE = '/api';
+const DEFAULT_GMAIL_REDIRECT_URI = 'http://localhost';
 
 const state = {
   drivers: [],
@@ -27,6 +28,10 @@ const state = {
   pendingCompletionComments: '',
   settings: {
     emailRecipient: '',
+    gmailClientId: '',
+    gmailClientSecret: '',
+    gmailRefreshToken: '',
+    gmailRedirectUri: '',
     loaded: false,
     saving: false,
   },
@@ -130,6 +135,10 @@ const elements = {
   noArchive: document.getElementById('no-archive'),
   emailSettingsForm: document.getElementById('email-settings-form'),
   emailRecipientInput: document.getElementById('email-recipient'),
+  gmailClientIdInput: document.getElementById('gmail-client-id'),
+  gmailClientSecretInput: document.getElementById('gmail-client-secret'),
+  gmailRefreshTokenInput: document.getElementById('gmail-refresh-token'),
+  gmailRedirectUriInput: document.getElementById('gmail-redirect-uri'),
   emailSettingsStatus: document.getElementById('email-settings-status'),
 };
 
@@ -343,7 +352,15 @@ function setAdminSession(admin) {
   state.isAdmin = true;
   state.adminFilters = { driverId: 'all', range: 'week' };
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
-  state.settings = { emailRecipient: '', loaded: false, saving: false };
+  state.settings = {
+    emailRecipient: '',
+    gmailClientId: '',
+    gmailClientSecret: '',
+    gmailRefreshToken: '',
+    gmailRedirectUri: '',
+    loaded: false,
+    saving: false,
+  };
   updateArchivePeriodInputs();
 
   hideElement(elements.loginPage);
@@ -357,6 +374,18 @@ function setAdminSession(admin) {
 
   if (elements.emailRecipientInput) {
     elements.emailRecipientInput.value = '';
+  }
+  if (elements.gmailClientIdInput) {
+    elements.gmailClientIdInput.value = '';
+  }
+  if (elements.gmailClientSecretInput) {
+    elements.gmailClientSecretInput.value = '';
+  }
+  if (elements.gmailRefreshTokenInput) {
+    elements.gmailRefreshTokenInput.value = '';
+  }
+  if (elements.gmailRedirectUriInput) {
+    elements.gmailRedirectUriInput.value = '';
   }
   resetEmailSettingsStatus();
 
@@ -531,7 +560,15 @@ function logout() {
   state.archivedCourses = [];
   state.adminFilters = { driverId: 'all', range: 'week' };
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
-  state.settings = { emailRecipient: '', loaded: false, saving: false };
+  state.settings = {
+    emailRecipient: '',
+    gmailClientId: '',
+    gmailClientSecret: '',
+    gmailRefreshToken: '',
+    gmailRedirectUri: '',
+    loaded: false,
+    saving: false,
+  };
   state.activityLog = [];
   state.courseCache.clear();
   elements.lastnameInput.value = '';
@@ -562,6 +599,18 @@ function logout() {
   }
   if (elements.emailRecipientInput) {
     elements.emailRecipientInput.value = '';
+  }
+  if (elements.gmailClientIdInput) {
+    elements.gmailClientIdInput.value = '';
+  }
+  if (elements.gmailClientSecretInput) {
+    elements.gmailClientSecretInput.value = '';
+  }
+  if (elements.gmailRefreshTokenInput) {
+    elements.gmailRefreshTokenInput.value = '';
+  }
+  if (elements.gmailRedirectUriInput) {
+    elements.gmailRedirectUriInput.value = '';
   }
   resetEmailSettingsStatus();
   state.adminView = 'planning';
@@ -1076,21 +1125,51 @@ function showEmailSettingsStatus(message, isError = false) {
 }
 
 async function loadEmailSettings(force = false) {
-  if (!elements.emailRecipientInput) {
+  if (!elements.emailSettingsForm) {
     return;
   }
 
   if (state.settings.loaded && !force) {
     elements.emailRecipientInput.value = state.settings.emailRecipient;
+    if (elements.gmailClientIdInput) {
+      elements.gmailClientIdInput.value = state.settings.gmailClientId;
+    }
+    if (elements.gmailClientSecretInput) {
+      elements.gmailClientSecretInput.value = state.settings.gmailClientSecret;
+    }
+    if (elements.gmailRefreshTokenInput) {
+      elements.gmailRefreshTokenInput.value = state.settings.gmailRefreshToken;
+    }
+    if (elements.gmailRedirectUriInput) {
+      elements.gmailRedirectUriInput.value =
+        state.settings.gmailRedirectUri || DEFAULT_GMAIL_REDIRECT_URI;
+    }
     return;
   }
 
   try {
     resetEmailSettingsStatus();
-    const response = await apiFetch('/settings/email-recipient');
-    state.settings.emailRecipient = response.email || '';
+    const response = await apiFetch('/settings/email-config');
+    state.settings.emailRecipient = response.recipient || '';
+    state.settings.gmailClientId = response.gmailClientId || '';
+    state.settings.gmailClientSecret = response.gmailClientSecret || '';
+    state.settings.gmailRefreshToken = response.gmailRefreshToken || '';
+    state.settings.gmailRedirectUri = response.gmailRedirectUri || '';
     state.settings.loaded = true;
     elements.emailRecipientInput.value = state.settings.emailRecipient;
+    if (elements.gmailClientIdInput) {
+      elements.gmailClientIdInput.value = state.settings.gmailClientId;
+    }
+    if (elements.gmailClientSecretInput) {
+      elements.gmailClientSecretInput.value = state.settings.gmailClientSecret;
+    }
+    if (elements.gmailRefreshTokenInput) {
+      elements.gmailRefreshTokenInput.value = state.settings.gmailRefreshToken;
+    }
+    if (elements.gmailRedirectUriInput) {
+      elements.gmailRedirectUriInput.value =
+        state.settings.gmailRedirectUri || DEFAULT_GMAIL_REDIRECT_URI;
+    }
   } catch (error) {
     console.error('Erreur lors du chargement de la configuration email', error);
     showEmailSettingsStatus(error.message || "Impossible de charger l'adresse email.", true);
@@ -1100,7 +1179,7 @@ async function loadEmailSettings(force = false) {
 async function handleEmailSettingsSubmit(event) {
   event.preventDefault();
 
-  if (!elements.emailRecipientInput) {
+  if (!elements.emailSettingsForm) {
     return;
   }
 
@@ -1108,14 +1187,29 @@ async function handleEmailSettingsSubmit(event) {
     return;
   }
 
-  const email = elements.emailRecipientInput.value.trim();
+  const email = elements.emailRecipientInput?.value.trim() || '';
+  const gmailClientId = elements.gmailClientIdInput?.value.trim() || '';
+  const gmailClientSecret = elements.gmailClientSecretInput?.value.trim() || '';
+  const gmailRefreshToken = elements.gmailRefreshTokenInput?.value.trim() || '';
+  const gmailRedirectUri =
+    elements.gmailRedirectUriInput?.value.trim() || DEFAULT_GMAIL_REDIRECT_URI;
 
   if (!email) {
     showEmailSettingsStatus('Veuillez renseigner une adresse email.', true);
     return;
   }
 
-  const submitButton = elements.emailSettingsForm?.querySelector('button[type="submit"]');
+  if (!gmailClientId || !gmailClientSecret || !gmailRefreshToken) {
+    showEmailSettingsStatus('Veuillez renseigner les identifiants Gmail requis.', true);
+    return;
+  }
+
+  if (!gmailRedirectUri) {
+    showEmailSettingsStatus('Veuillez renseigner une Redirect URI Gmail.', true);
+    return;
+  }
+
+  const submitButton = elements.emailSettingsForm.querySelector('button[type="submit"]');
 
   try {
     state.settings.saving = true;
@@ -1125,18 +1219,43 @@ async function handleEmailSettingsSubmit(event) {
       submitButton.classList.add('opacity-50', 'cursor-not-allowed');
     }
 
-    const response = await apiFetch('/settings/email-recipient', {
+    const response = await apiFetch('/settings/email-config', {
       method: 'PUT',
-      body: JSON.stringify({ email }),
+      body: JSON.stringify({
+        recipient: email,
+        gmailClientId,
+        gmailClientSecret,
+        gmailRefreshToken,
+        gmailRedirectUri,
+      }),
     });
 
-    state.settings.emailRecipient = response.email || email;
+    state.settings.emailRecipient = response.recipient || email;
+    state.settings.gmailClientId = response.gmailClientId || gmailClientId;
+    state.settings.gmailClientSecret = response.gmailClientSecret || gmailClientSecret;
+    state.settings.gmailRefreshToken = response.gmailRefreshToken || gmailRefreshToken;
+    state.settings.gmailRedirectUri = response.gmailRedirectUri || gmailRedirectUri;
     state.settings.loaded = true;
+
     elements.emailRecipientInput.value = state.settings.emailRecipient;
-    showEmailSettingsStatus('Adresse email mise à jour avec succès.');
+    if (elements.gmailClientIdInput) {
+      elements.gmailClientIdInput.value = state.settings.gmailClientId;
+    }
+    if (elements.gmailClientSecretInput) {
+      elements.gmailClientSecretInput.value = state.settings.gmailClientSecret;
+    }
+    if (elements.gmailRefreshTokenInput) {
+      elements.gmailRefreshTokenInput.value = state.settings.gmailRefreshToken;
+    }
+    if (elements.gmailRedirectUriInput) {
+      elements.gmailRedirectUriInput.value =
+        state.settings.gmailRedirectUri || DEFAULT_GMAIL_REDIRECT_URI;
+    }
+
+    showEmailSettingsStatus('Configuration email mise à jour avec succès.');
   } catch (error) {
-    console.error("Erreur lors de l'enregistrement de l'adresse email", error);
-    showEmailSettingsStatus(error.message || 'Impossible de mettre à jour cette adresse.', true);
+    console.error("Erreur lors de l'enregistrement de la configuration email", error);
+    showEmailSettingsStatus(error.message || 'Impossible de mettre à jour la configuration email.', true);
   } finally {
     state.settings.saving = false;
     if (submitButton) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -955,7 +955,11 @@ function ensureSettingsData(tab = state.settings.activeTab) {
   } else if (tab === 'drivers') {
     loadDriverCredentials();
   } else if (tab === 'admins' && state.currentUser?.adminLevel === 'superadmin') {
-    renderAdminManagement();
+    if (!state.admins.length) {
+      loadAdmins();
+    } else {
+      renderAdminManagement();
+    }
   }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -48,6 +48,19 @@ const state = {
     loading: false,
     editingDriverId: null,
   },
+  courseIssue: {
+    courseId: null,
+    submitting: false,
+  },
+  messaging: {
+    unreadCount: 0,
+    isOpen: false,
+    loading: false,
+    messages: [],
+    threads: [],
+    activeDriverId: null,
+    sending: false,
+  },
   settings: {
     emailRecipient: '',
     loaded: false,
@@ -136,6 +149,12 @@ const elements = {
   driverPasswordCancel: document.getElementById('driver-password-cancel'),
   driverPasswordError: document.getElementById('driver-password-error'),
   driverPasswordName: document.getElementById('driver-password-name'),
+  courseIssueModal: document.getElementById('course-issue-modal'),
+  courseIssueForm: document.getElementById('course-issue-form'),
+  courseIssueComment: document.getElementById('course-issue-comment'),
+  courseIssueError: document.getElementById('course-issue-error'),
+  courseIssueCancel: document.getElementById('course-issue-cancel'),
+  courseIssueClose: document.getElementById('course-issue-close'),
   driverManagementForm: document.getElementById('driver-management-form'),
   driverFirstNameInput: document.getElementById('driver-first-name'),
   driverLastNameInput: document.getElementById('driver-last-name'),
@@ -158,6 +177,18 @@ const elements = {
   noArchive: document.getElementById('no-archive'),
   emailSettingsForm: document.getElementById('email-settings-form'),
   emailRecipientInput: document.getElementById('email-recipient'),
+  messagingFab: document.getElementById('messaging-fab'),
+  messagingToggle: document.getElementById('messaging-toggle'),
+  messagingUnread: document.getElementById('messaging-unread'),
+  messagingPanel: document.getElementById('messaging-panel'),
+  messagingClose: document.getElementById('messaging-close'),
+  messagingMessages: document.getElementById('messaging-messages'),
+  messagingForm: document.getElementById('messaging-form'),
+  messagingInput: document.getElementById('messaging-input'),
+  messagingError: document.getElementById('messaging-error'),
+  messagingThreadList: document.getElementById('messaging-thread-list'),
+  messagingDriverPicker: document.getElementById('messaging-driver-picker'),
+  messagingSubtitle: document.getElementById('messaging-subtitle'),
   emailSettingsStatus: document.getElementById('email-settings-status'),
   settingsTabButtons: document.querySelectorAll('[data-settings-tab]'),
   settingsPanels: document.querySelectorAll('[data-settings-panel]'),
@@ -255,6 +286,18 @@ function normalizeAdmin(admin) {
   };
 }
 
+function escapeHtml(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function mapCourse(course) {
   const date = new Date(course.dateTime || course.date_time || course.date);
   const normalized = {
@@ -267,6 +310,8 @@ function mapCourse(course) {
     merchandise: course.merchandise || '',
     comments: course.comments || '',
     status: course.status,
+    issueReportedAt: course.issueReportedAt || course.issue_reported_at || null,
+    issueReportComment: course.issueReportComment || course.issue_report_comment || '',
     photoUrl: course.photoUrl || course.photo_path || null,
     completionComments: course.completionComments || course.completion_comments || '',
     createdAt: course.createdAt || course.created_at || null,
@@ -277,6 +322,41 @@ function mapCourse(course) {
 
   state.courseCache.set(normalized.id, normalized);
   return normalized;
+}
+
+function getCourseStatusMeta(course, { archivedClass = 'bg-gray-200 text-gray-600' } = {}) {
+  if (!course) {
+    return {
+      label: 'Inconnu',
+      className: 'bg-gray-200 text-gray-600',
+    };
+  }
+
+  if (course.isArchived) {
+    return {
+      label: 'Archivée',
+      className: archivedClass,
+    };
+  }
+
+  if (course.status === 'completed') {
+    return {
+      label: 'Terminé',
+      className: 'bg-green-100 text-green-800',
+    };
+  }
+
+  if (course.status === 'issue_reported') {
+    return {
+      label: 'En attente',
+      className: 'bg-red-100 text-red-700',
+    };
+  }
+
+  return {
+    label: 'À faire',
+    className: 'bg-yellow-100 text-yellow-800',
+  };
 }
 
 function startOfDay(date) {
@@ -412,6 +492,7 @@ async function loginAsDriver(driver, options = {}) {
   state.activeDriverTab = initialTab;
   switchTab(initialTab);
   await loadDriverCourses();
+  updateMessagingAvailability();
   persistSessionState();
 }
 
@@ -592,6 +673,7 @@ function setAdminSession(admin, options = {}) {
   if (state.currentUser.adminLevel === 'superadmin') {
     loadAdmins();
   }
+  updateMessagingAvailability();
   persistSessionState();
 }
 
@@ -1070,6 +1152,7 @@ async function logout(event) {
   state.activityLog = [];
   state.courseCache.clear();
   resetAdminEditState();
+  resetMessagingState();
   elements.lastnameInput.value = '';
   elements.driverList.innerHTML = '';
   hideElement(elements.driverDashboard);
@@ -2114,16 +2197,7 @@ function renderTodayCourses() {
       container.className = `${baseClasses} ${archived ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`;
       container.setAttribute('aria-disabled', archived ? 'true' : 'false');
 
-      const statusClass = archived
-        ? 'bg-gray-200 text-gray-600'
-        : course.status === 'completed'
-        ? 'bg-green-100 text-green-800'
-        : 'bg-yellow-100 text-yellow-800';
-      const statusLabel = archived
-        ? 'Archivée'
-        : course.status === 'completed'
-        ? 'Terminé'
-        : 'À faire';
+      const statusMeta = getCourseStatusMeta(course);
 
       container.innerHTML = `
         <div class="flex justify-between items-start">
@@ -2131,8 +2205,8 @@ function renderTodayCourses() {
             <div class="font-medium">${course.departure} → ${course.destination}</div>
             <div class="text-sm text-gray-500 mt-1">${formatTime(course.date)} • ${course.merchandise}</div>
           </div>
-          <span class="px-2 py-1 text-xs rounded-full ${statusClass}">
-            ${statusLabel}
+          <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">
+            ${statusMeta.label}
           </span>
         </div>
         ${course.comments ? `<div class="mt-2 text-sm text-gray-600"><i class="fas fa-comment mr-1"></i> ${course.comments}</div>` : ''}
@@ -2140,6 +2214,28 @@ function renderTodayCourses() {
 
       if (!archived) {
         container.addEventListener('click', () => openCourseModal(course.id));
+      }
+
+      if (course.status === 'issue_reported' && course.issueReportComment) {
+        const issueNotice = document.createElement('div');
+        issueNotice.className = 'mt-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2';
+        issueNotice.textContent = `Problème signalé : ${course.issueReportComment || 'Détail non renseigné'}`;
+        container.appendChild(issueNotice);
+      }
+
+      if (!archived && course.status !== 'completed' && course.status !== 'issue_reported') {
+        const buttonWrapper = document.createElement('div');
+        buttonWrapper.className = 'mt-3 flex justify-end';
+        const issueButton = document.createElement('button');
+        issueButton.type = 'button';
+        issueButton.className = 'inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100';
+        issueButton.innerHTML = '<i class="fas fa-exclamation-triangle mr-2"></i>Signaler un problème';
+        issueButton.addEventListener('click', (event) => {
+          event.stopPropagation();
+          openCourseIssueModal(course.id);
+        });
+        buttonWrapper.appendChild(issueButton);
+        container.appendChild(buttonWrapper);
       }
 
       elements.todayList.appendChild(container);
@@ -2165,16 +2261,9 @@ function renderWeekCourses() {
       row.className = `${archived ? 'bg-gray-100 text-gray-500 cursor-not-allowed' : 'hover:bg-gray-50 cursor-pointer'}`;
       row.setAttribute('aria-disabled', archived ? 'true' : 'false');
 
-      const statusClass = archived
-        ? 'bg-gray-200 text-gray-600'
-        : course.status === 'completed'
-        ? 'bg-green-100 text-green-800'
-        : 'bg-yellow-100 text-yellow-800';
-      const statusLabel = archived
-        ? 'Archivée'
-        : course.status === 'completed'
-        ? 'Terminé'
-        : 'À faire';
+      const statusMeta = getCourseStatusMeta(course, {
+        archivedClass: 'bg-gray-300 text-gray-700',
+      });
 
       row.innerHTML = `
         <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Date">${formatDate(course.date)}</td>
@@ -2182,9 +2271,14 @@ function renderWeekCourses() {
         <td class="px-6 py-4 text-sm" data-label="Arrivée">${course.destination}</td>
         <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Horaire">${formatTime(course.date)}</td>
         <td class="px-6 py-4" data-label="Statut">
-          <span class="px-2 py-1 text-xs rounded-full ${statusClass}">
-            ${statusLabel}
-          </span>
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">
+              ${statusMeta.label}
+            </span>
+            ${!archived && course.status !== 'completed' && course.status !== 'issue_reported'
+              ? '<button type="button" class="issue-button text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-md px-2 py-1 hover:bg-red-100"><i class="fas fa-exclamation-triangle mr-1"></i>Signaler un problème</button>'
+              : ''}
+          </div>
         </td>
       `;
 
@@ -2192,7 +2286,28 @@ function renderWeekCourses() {
         row.addEventListener('click', () => openCourseModal(course.id));
       }
 
-      elements.weekList.appendChild(row);
+      if (course.status === 'issue_reported' && course.issueReportComment) {
+        const detailRow = document.createElement('tr');
+        detailRow.className = 'bg-red-50';
+        const cell = document.createElement('td');
+        cell.colSpan = 5;
+        cell.className = 'px-6 py-3 text-sm text-red-700 border-t border-red-100';
+        const issueText = course.issueReportComment || 'Détail non renseigné';
+        cell.innerHTML = `<i class="fas fa-circle-exclamation mr-2"></i>Problème signalé : ${escapeHtml(issueText)}`;
+        detailRow.appendChild(cell);
+        elements.weekList.appendChild(row);
+        elements.weekList.appendChild(detailRow);
+      } else {
+        elements.weekList.appendChild(row);
+      }
+
+      const issueButton = row.querySelector('.issue-button');
+      if (issueButton) {
+        issueButton.addEventListener('click', (event) => {
+          event.stopPropagation();
+          openCourseIssueModal(course.id);
+        });
+      }
     });
 }
 
@@ -2212,8 +2327,9 @@ function renderAdminCourses() {
     .forEach((course) => {
       const row = document.createElement('tr');
       row.className = 'hover:bg-gray-50';
-      const statusClass =
-        course.status === 'completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800';
+      const statusMeta = getCourseStatusMeta(course, {
+        archivedClass: 'bg-gray-200 text-gray-600',
+      });
 
       row.innerHTML = `
         <td class="px-6 py-4 text-sm" data-label="Chauffeur">${course.driverName || ''}</td>
@@ -2222,9 +2338,14 @@ function renderAdminCourses() {
         <td class="px-6 py-4 text-sm" data-label="Arrivée">${course.destination}</td>
         <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Horaire">${formatTime(course.date)}</td>
         <td class="px-6 py-4" data-label="Statut">
-          <span class="px-2 py-1 text-xs rounded-full ${statusClass}">
-            ${course.status === 'completed' ? 'Terminé' : 'À faire'}
-          </span>
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">
+              ${statusMeta.label}
+            </span>
+            ${course.status === 'issue_reported'
+              ? '<span class="text-xs font-medium text-red-700"><i class="fas fa-circle-exclamation mr-1"></i>Problème en attente</span>'
+              : ''}
+          </div>
         </td>
         <td class="px-6 py-4 text-sm font-medium sm:text-right" data-label="Actions">
           <div class="flex flex-wrap gap-3 sm:justify-end">
@@ -2320,6 +2441,8 @@ function renderActivityLog() {
           ? 'a archivé une course'
           : item.action === 'restored'
           ? 'a restauré une course'
+          : item.action === 'issue_reported'
+          ? 'a signalé un problème sur une course'
           : item.action;
       primaryText = `${item.user} ${actionText}${driverSuffix}`;
     }
@@ -2618,6 +2741,16 @@ async function openCourseModal(courseId) {
             <p class="mt-1 text-sm text-gray-900">${course.comments}</p>
           </div>
         ` : ''}
+        ${course.status === 'issue_reported' ? `
+          <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2">
+            <div class="text-sm font-medium text-red-700 flex items-center gap-2">
+              <i class="fas fa-circle-exclamation"></i>
+              <span>Problème signalé</span>
+            </div>
+            <p class="mt-2 text-sm text-red-700">${escapeHtml(course.issueReportComment || 'Commentaire non renseigné')}</p>
+            ${course.issueReportedAt ? `<p class="mt-1 text-xs text-red-500">Signalé le ${new Date(course.issueReportedAt).toLocaleString('fr-FR')}</p>` : ''}
+          </div>
+        ` : ''}
         ${course.status === 'completed' ? `
           <div>
             <h4 class="text-sm font-medium text-gray-500">Photo du bon</h4>
@@ -2659,7 +2792,7 @@ async function openCourseModal(courseId) {
       deleteButton.innerHTML = '<i class="fas fa-trash mr-1"></i> Supprimer';
       deleteButton.addEventListener('click', () => deleteCourse(course.id));
       elements.modalActions.appendChild(deleteButton);
-    } else if (course.status !== 'completed' && !isArchived) {
+    } else if (course.status !== 'completed' && course.status !== 'issue_reported' && !isArchived) {
       const validateButton = document.createElement('button');
       validateButton.type = 'button';
       validateButton.className = 'px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition';
@@ -2728,6 +2861,607 @@ function closePhotoModal() {
 
   hideElement(elements.photoModal);
   state.photoDataUrl = null;
+}
+
+function openCourseIssueModal(courseId) {
+  if (state.currentUser?.role !== 'driver') {
+    return;
+  }
+
+  const course = state.courseCache.get(courseId);
+  if (!course || course.isArchived || course.status === 'completed' || course.status === 'issue_reported') {
+    return;
+  }
+
+  state.courseIssue.courseId = courseId;
+  state.courseIssue.submitting = false;
+  elements.courseIssueComment.value = '';
+  elements.courseIssueError.classList.add('hidden');
+  showElement(elements.courseIssueModal);
+}
+
+function closeCourseIssueModal() {
+  state.courseIssue.courseId = null;
+  state.courseIssue.submitting = false;
+  elements.courseIssueComment.value = '';
+  elements.courseIssueError.classList.add('hidden');
+  hideElement(elements.courseIssueModal);
+}
+
+async function handleCourseIssueSubmit(event) {
+  event.preventDefault();
+
+  if (!state.courseIssue.courseId) {
+    return;
+  }
+
+  const comment = elements.courseIssueComment.value.trim();
+  if (!comment) {
+    elements.courseIssueError.textContent = 'Veuillez renseigner un commentaire.';
+    elements.courseIssueError.classList.remove('hidden');
+    return;
+  }
+
+  try {
+    state.courseIssue.submitting = true;
+    elements.courseIssueError.classList.add('hidden');
+    const submitBtn = elements.courseIssueForm.querySelector('button[type="submit"]');
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.classList.add('opacity-75');
+    }
+
+    await apiFetch(`/courses/${state.courseIssue.courseId}/report-issue`, {
+      method: 'POST',
+      body: JSON.stringify({
+        driverId: state.currentUser?.id,
+        comment,
+      }),
+    });
+
+    closeCourseIssueModal();
+    await loadDriverCourses();
+  } catch (error) {
+    console.error('Erreur lors du signalement du problème', error);
+    elements.courseIssueError.textContent = error.message || 'Impossible de signaler le problème.';
+    elements.courseIssueError.classList.remove('hidden');
+  } finally {
+    state.courseIssue.submitting = false;
+    const submitBtn = elements.courseIssueForm.querySelector('button[type="submit"]');
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.classList.remove('opacity-75');
+    }
+  }
+}
+
+function resetMessagingState({ preserveAvailability = false } = {}) {
+  state.messaging.unreadCount = 0;
+  state.messaging.isOpen = false;
+  state.messaging.loading = false;
+  state.messaging.messages = [];
+  state.messaging.threads = [];
+  state.messaging.activeDriverId = null;
+  state.messaging.sending = false;
+
+  if (elements.messagingInput) {
+    elements.messagingInput.value = '';
+  }
+  if (elements.messagingError) {
+    elements.messagingError.textContent = '';
+    elements.messagingError.classList.add('hidden');
+  }
+  if (elements.messagingMessages) {
+    elements.messagingMessages.innerHTML = '';
+  }
+  if (elements.messagingThreadList) {
+    elements.messagingThreadList.innerHTML = '';
+  }
+  if (elements.messagingUnread) {
+    elements.messagingUnread.classList.add('hidden');
+    elements.messagingUnread.textContent = '0';
+  }
+
+  hideElement(elements.messagingPanel);
+  if (!preserveAvailability) {
+    hideElement(elements.messagingFab);
+  }
+}
+
+function updateMessagingSubtitle() {
+  if (!elements.messagingSubtitle) {
+    return;
+  }
+
+  if (!state.currentUser) {
+    elements.messagingSubtitle.textContent = '';
+    return;
+  }
+
+  if (state.currentUser.role === 'driver') {
+    elements.messagingSubtitle.textContent = "Contactez l'administration en direct.";
+  } else {
+    elements.messagingSubtitle.textContent = 'Répondez instantanément aux messages des chauffeurs.';
+  }
+}
+
+function updateMessagingBadge() {
+  if (!elements.messagingUnread) {
+    return;
+  }
+
+  if (state.messaging.unreadCount > 0) {
+    elements.messagingUnread.textContent = String(state.messaging.unreadCount);
+    elements.messagingUnread.classList.remove('hidden');
+  } else {
+    elements.messagingUnread.textContent = '0';
+    elements.messagingUnread.classList.add('hidden');
+  }
+}
+
+function updateMessagingAvailability() {
+  if (!elements.messagingFab || !elements.messagingPanel) {
+    return;
+  }
+
+  if (!state.currentUser) {
+    resetMessagingState();
+    return;
+  }
+
+  showElement(elements.messagingFab);
+  updateMessagingSubtitle();
+  refreshMessagingUnreadCount();
+}
+
+async function refreshMessagingUnreadCount() {
+  if (!state.currentUser) {
+    return;
+  }
+
+  try {
+    if (state.currentUser.role === 'driver') {
+      const data = await apiFetch(
+        `/messages/unread-count?role=driver&driverId=${encodeURIComponent(state.currentUser.id)}`
+      );
+      state.messaging.unreadCount = data?.total || 0;
+    } else {
+      const data = await apiFetch('/messages/unread-count?role=admin');
+      state.messaging.unreadCount = data?.total || 0;
+      state.messaging.threads = Array.isArray(data?.perDriver) ? data.perDriver : [];
+    }
+  } catch (error) {
+    console.warn('Impossible de récupérer le nombre de messages non lus', error);
+    state.messaging.unreadCount = 0;
+  }
+
+  updateMessagingBadge();
+}
+
+function renderMessagingThreads() {
+  if (!elements.messagingThreadList) {
+    return;
+  }
+
+  elements.messagingThreadList.innerHTML = '';
+
+  if (!state.messaging.threads.length) {
+    const empty = document.createElement('p');
+    empty.className = 'text-xs text-slate-500';
+    empty.textContent = 'Aucune conversation pour le moment';
+    elements.messagingThreadList.appendChild(empty);
+    return;
+  }
+
+  state.messaging.threads
+    .slice()
+    .sort((a, b) => new Date(b.lastMessageAt || 0) - new Date(a.lastMessageAt || 0))
+    .forEach((thread) => {
+      const item = document.createElement('div');
+      item.className = `messaging-thread${
+        thread.driverId === state.messaging.activeDriverId ? ' messaging-thread--active' : ''
+      }`;
+      item.setAttribute('data-driver-id', thread.driverId);
+
+      const name = document.createElement('div');
+      name.className = 'messaging-thread__name';
+      name.textContent = thread.driverName || `Chauffeur #${thread.driverId}`;
+      item.appendChild(name);
+
+      const meta = document.createElement('div');
+      meta.className = 'messaging-thread__meta';
+
+      const when = document.createElement('span');
+      when.textContent = thread.lastMessageAt
+        ? new Date(thread.lastMessageAt).toLocaleString('fr-FR', {
+            hour: '2-digit',
+            minute: '2-digit',
+            day: '2-digit',
+            month: 'short',
+          })
+        : '';
+      meta.appendChild(when);
+
+      if (thread.count || thread.unreadFromDriver) {
+        const badge = document.createElement('span');
+        badge.className = 'messaging-thread__badge';
+        badge.textContent = String(thread.count || thread.unreadFromDriver || 0);
+        meta.appendChild(badge);
+      }
+
+      item.appendChild(meta);
+      elements.messagingThreadList.appendChild(item);
+    });
+}
+
+function renderMessagingMessages() {
+  if (!elements.messagingMessages) {
+    return;
+  }
+
+  elements.messagingMessages.innerHTML = '';
+
+  if (!state.messaging.messages.length) {
+    const empty = document.createElement('p');
+    empty.className = 'text-sm text-slate-500 text-center';
+    empty.textContent = 'Envoyez un premier message pour démarrer la conversation.';
+    elements.messagingMessages.appendChild(empty);
+    return;
+  }
+
+  state.messaging.messages.forEach((message) => {
+    const container = document.createElement('div');
+    const isMine =
+      (state.currentUser?.role === 'driver' && message.senderType === 'driver') ||
+      (state.currentUser?.role === 'admin' && message.senderType === 'admin' &&
+        (!message.senderId || message.senderId === state.currentUser.id));
+    container.className = `messaging-message${isMine ? ' messaging-message--mine' : ''}`;
+
+    const avatar = document.createElement('div');
+    avatar.className = 'messaging-message__avatar';
+    avatar.textContent = (message.senderInitials || '').slice(0, 3) || '??';
+    container.appendChild(avatar);
+
+    const bubble = document.createElement('div');
+    bubble.className = 'messaging-message__bubble';
+
+    const label = document.createElement('strong');
+    label.textContent = message.senderLabel || (message.senderType === 'driver' ? 'Chauffeur' : 'Admin');
+    bubble.appendChild(label);
+
+    const body = document.createElement('p');
+    body.textContent = message.body;
+    bubble.appendChild(body);
+
+    const meta = document.createElement('div');
+    meta.className = 'messaging-message__meta';
+    meta.textContent = new Date(message.createdAt).toLocaleString('fr-FR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: 'short',
+    });
+    bubble.appendChild(meta);
+
+    container.appendChild(bubble);
+    elements.messagingMessages.appendChild(container);
+  });
+
+  elements.messagingMessages.scrollTop = elements.messagingMessages.scrollHeight;
+}
+
+async function markConversationAsRead(driverId, readerType) {
+  try {
+    await apiFetch(`/messages/${driverId}/read`, {
+      method: 'POST',
+      body: JSON.stringify({ readerType }),
+    });
+  } catch (error) {
+    console.warn('Impossible de marquer la conversation comme lue', error);
+  }
+}
+
+async function loadMessagingConversation(driverId, { markRead = true } = {}) {
+  if (!driverId) {
+    return;
+  }
+
+  state.messaging.loading = true;
+  renderMessagingMessages();
+
+  try {
+    const role = state.currentUser?.role === 'admin' ? 'admin' : 'driver';
+    const query = role === 'admin' ? 'role=admin' : `role=driver&driverId=${encodeURIComponent(driverId)}`;
+    const data = await apiFetch(`/messages/threads/${driverId}?${query}`);
+    const messages = Array.isArray(data?.messages) ? data.messages : [];
+    state.messaging.messages = messages;
+    renderMessagingMessages();
+
+    if (markRead) {
+      await markConversationAsRead(driverId, role);
+      await refreshMessagingUnreadCount();
+    }
+  } catch (error) {
+    console.error('Erreur lors du chargement de la conversation', error);
+    elements.messagingError.textContent = error.message || 'Impossible de charger les messages.';
+    elements.messagingError.classList.remove('hidden');
+  } finally {
+    state.messaging.loading = false;
+  }
+}
+
+async function loadMessagingInbox() {
+  try {
+    const inbox = await apiFetch('/messages/inbox');
+    state.messaging.threads = Array.isArray(inbox)
+      ? inbox.map((thread) => ({
+          driverId: thread.driverId,
+          driverName: thread.driverName,
+          lastMessageAt: thread.lastMessageAt,
+          count: thread.unreadFromDriver || thread.count || 0,
+        }))
+      : [];
+    renderMessagingThreads();
+  } catch (error) {
+    console.warn('Impossible de charger la liste des conversations', error);
+    state.messaging.threads = [];
+    renderMessagingThreads();
+  }
+}
+
+function populateMessagingDriverPicker() {
+  if (!elements.messagingDriverPicker) {
+    return;
+  }
+
+  if (state.currentUser?.role !== 'admin') {
+    elements.messagingDriverPicker.classList.add('hidden');
+    return;
+  }
+
+  elements.messagingDriverPicker.classList.remove('hidden');
+  elements.messagingDriverPicker.innerHTML = '<option value="">Choisir un chauffeur...</option>';
+
+  (state.adminDrivers || []).forEach((driver) => {
+    const option = document.createElement('option');
+    option.value = driver.id;
+    option.textContent = `${driver.firstName} ${driver.lastName}`;
+    if (driver.id === state.messaging.activeDriverId) {
+      option.selected = true;
+    }
+    elements.messagingDriverPicker.appendChild(option);
+  });
+}
+
+async function ensureAdminDriversForMessaging() {
+  if (state.currentUser?.role !== 'admin') {
+    return;
+  }
+
+  if (!state.adminDrivers.length) {
+    await loadAdminDrivers({ force: true });
+  }
+  populateMessagingDriverPicker();
+}
+
+async function openMessagingPanel() {
+  if (!state.currentUser) {
+    return;
+  }
+
+  state.messaging.isOpen = true;
+  elements.messagingError.classList.add('hidden');
+  elements.messagingMessages.innerHTML = '';
+  showElement(elements.messagingPanel);
+
+  if (state.currentUser.role === 'driver') {
+    elements.messagingThreadList?.classList.add('hidden');
+    elements.messagingDriverPicker?.classList.add('hidden');
+    state.messaging.activeDriverId = state.currentUser.id;
+    await loadMessagingConversation(state.messaging.activeDriverId);
+  } else {
+    elements.messagingThreadList?.classList.remove('hidden');
+    await ensureAdminDriversForMessaging();
+    await loadMessagingInbox();
+
+    if (!state.messaging.activeDriverId) {
+      if (state.messaging.threads.length) {
+        state.messaging.activeDriverId = state.messaging.threads[0].driverId;
+      } else if (state.adminDrivers.length) {
+        state.messaging.activeDriverId = state.adminDrivers[0].id;
+      }
+    }
+
+    populateMessagingDriverPicker();
+
+    if (state.messaging.activeDriverId) {
+      await loadMessagingConversation(state.messaging.activeDriverId);
+      if (elements.messagingDriverPicker) {
+        elements.messagingDriverPicker.value = String(state.messaging.activeDriverId);
+      }
+    } else {
+      renderMessagingMessages();
+    }
+  }
+
+  state.messaging.unreadCount = 0;
+  updateMessagingBadge();
+}
+
+function closeMessagingPanel() {
+  state.messaging.isOpen = false;
+  hideElement(elements.messagingPanel);
+}
+
+function toggleMessagingPanel() {
+  if (state.messaging.isOpen) {
+    closeMessagingPanel();
+  } else {
+    openMessagingPanel();
+  }
+}
+
+function selectMessagingThread(driverId) {
+  if (!driverId || state.messaging.activeDriverId === driverId) {
+    return;
+  }
+  state.messaging.activeDriverId = driverId;
+  renderMessagingThreads();
+  loadMessagingConversation(driverId);
+  if (elements.messagingDriverPicker) {
+    elements.messagingDriverPicker.value = String(driverId);
+  }
+}
+
+async function handleMessagingSubmit(event) {
+  event.preventDefault();
+
+  if (!state.currentUser) {
+    return;
+  }
+
+  const body = elements.messagingInput.value.trim();
+  if (!body) {
+    elements.messagingError.textContent = 'Le message ne peut pas être vide.';
+    elements.messagingError.classList.remove('hidden');
+    return;
+  }
+
+  if (!state.messaging.activeDriverId) {
+    elements.messagingError.textContent = "Sélectionnez un chauffeur avant d'envoyer un message.";
+    elements.messagingError.classList.remove('hidden');
+    return;
+  }
+
+  try {
+    elements.messagingError.classList.add('hidden');
+    state.messaging.sending = true;
+    const payload = {
+      driverId: state.messaging.activeDriverId,
+      body,
+      senderType: state.currentUser.role === 'admin' ? 'admin' : 'driver',
+    };
+    const message = await apiFetch('/messages', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+
+    elements.messagingInput.value = '';
+    if (Array.isArray(state.messaging.messages)) {
+      state.messaging.messages.push(message);
+    } else {
+      state.messaging.messages = [message];
+    }
+    renderMessagingMessages();
+    await refreshMessagingUnreadCount();
+  } catch (error) {
+    console.error("Erreur lors de l'envoi du message", error);
+    elements.messagingError.textContent = error.message || "Impossible d'envoyer le message.";
+    elements.messagingError.classList.remove('hidden');
+  } finally {
+    state.messaging.sending = false;
+  }
+}
+
+function handleMessagingDriverChange(event) {
+  const value = Number.parseInt(event.target.value, 10);
+  if (Number.isInteger(value)) {
+    selectMessagingThread(value);
+  }
+}
+
+function handleMessagingThreadClick(event) {
+  const target = event.target.closest('[data-driver-id]');
+  if (!target) {
+    return;
+  }
+  const driverId = Number.parseInt(target.getAttribute('data-driver-id'), 10);
+  if (Number.isInteger(driverId)) {
+    selectMessagingThread(driverId);
+  }
+}
+
+function processRealtimeMessage(payload) {
+  if (!payload || !payload.message || !payload.driverId || !state.currentUser) {
+    return;
+  }
+
+  const driverId = Number(payload.driverId);
+  const message = payload.message;
+  const senderType = payload.senderType;
+
+  const isDriver = state.currentUser.role === 'driver' && driverId === state.currentUser.id;
+  const isAdmin = state.currentUser.role === 'admin';
+
+  if (!isDriver && !isAdmin) {
+    return;
+  }
+
+  if (isDriver && senderType === 'driver') {
+    return;
+  }
+
+  if (isAdmin && senderType === 'admin' && message.senderId && message.senderId === state.currentUser.id) {
+    return;
+  }
+
+  const isCurrentConversation = state.messaging.isOpen && state.messaging.activeDriverId === driverId;
+  const alreadyPresent = state.messaging.messages.some((existing) => existing.id === message.id);
+
+  if (isCurrentConversation && !alreadyPresent) {
+    state.messaging.messages.push(message);
+    renderMessagingMessages();
+
+    if (isDriver && senderType === 'admin') {
+      markConversationAsRead(driverId, 'driver');
+      refreshMessagingUnreadCount();
+    }
+
+    if (isAdmin && senderType === 'driver') {
+      markConversationAsRead(driverId, 'admin');
+      refreshMessagingUnreadCount();
+    }
+  } else if (!alreadyPresent) {
+    refreshMessagingUnreadCount();
+  }
+
+  if (isAdmin) {
+    const existing = state.messaging.threads.find((thread) => thread.driverId === driverId);
+    if (existing) {
+      existing.lastMessageAt = message.createdAt;
+      if (senderType === 'driver') {
+        existing.count = (existing.count || 0) + 1;
+      }
+    } else {
+      state.messaging.threads.push({
+        driverId,
+        driverName: message.senderLabel || `Chauffeur #${driverId}`,
+        lastMessageAt: message.createdAt,
+        count: senderType === 'driver' ? 1 : 0,
+      });
+    }
+    renderMessagingThreads();
+  }
+}
+
+function processMessageReadEvent(payload) {
+  if (!payload || !state.currentUser) {
+    return;
+  }
+
+  if (state.currentUser.role === 'driver') {
+    if (Number(payload.driverId) === state.currentUser.id && payload.readerType === 'driver') {
+      refreshMessagingUnreadCount();
+    }
+  } else if (state.currentUser.role === 'admin' && payload.readerType === 'admin') {
+    refreshMessagingUnreadCount();
+    if (state.messaging.threads.length) {
+      state.messaging.threads = state.messaging.threads.map((thread) =>
+        thread.driverId === Number(payload.driverId) ? { ...thread, count: 0 } : thread
+      );
+      renderMessagingThreads();
+    }
+  }
 }
 
 function capturePhoto() {
@@ -2898,6 +3632,12 @@ function handleRealtimeEvent(event) {
         loadEmailRecipient();
       }
       break;
+    case 'messages:new':
+      processRealtimeMessage(payload);
+      break;
+    case 'messages:read':
+      processMessageReadEvent(payload);
+      break;
     default:
       break;
   }
@@ -3034,6 +3774,14 @@ function registerEventListeners() {
   elements.captureBtn.addEventListener('click', capturePhoto);
   elements.confirmPhotoBtn.addEventListener('click', confirmPhoto);
   elements.retakePhotoBtn.addEventListener('click', retakePhoto);
+  elements.courseIssueForm?.addEventListener('submit', handleCourseIssueSubmit);
+  elements.courseIssueCancel?.addEventListener('click', closeCourseIssueModal);
+  elements.courseIssueClose?.addEventListener('click', closeCourseIssueModal);
+  elements.messagingToggle?.addEventListener('click', toggleMessagingPanel);
+  elements.messagingClose?.addEventListener('click', closeMessagingPanel);
+  elements.messagingForm?.addEventListener('submit', handleMessagingSubmit);
+  elements.messagingDriverPicker?.addEventListener('change', handleMessagingDriverChange);
+  elements.messagingThreadList?.addEventListener('click', handleMessagingThreadClick);
   elements.adminDriverSelect.addEventListener('change', () => {
     state.adminFilters.driverId = elements.adminDriverSelect.value || 'all';
     if (state.isAdmin) {
@@ -3124,6 +3872,12 @@ function registerEventListeners() {
     if (event.target === elements.driverPasswordModal) {
       closeDriverPasswordModal();
     }
+    if (event.target === elements.courseIssueModal) {
+      closeCourseIssueModal();
+    }
+    if (event.target === elements.messagingPanel) {
+      closeMessagingPanel();
+    }
   });
 }
 
@@ -3135,6 +3889,7 @@ function init() {
   renderSettingsTabs();
   registerEventListeners();
   setupRealtimeUpdates();
+  resetMessagingState();
   restoreSessionFromStorage();
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,6 +9,26 @@ const ADMIN_EDIT_DEFAULT = Object.freeze({
   saving: false,
 });
 
+const DEFAULT_ADMIN_FILTERS = Object.freeze({
+  driverId: 'all',
+  range: 'week',
+  status: 'all',
+  merchandise: 'all',
+  issue: 'all',
+  hasPhoto: 'all',
+  search: '',
+  from: null,
+  to: null,
+});
+
+const DEFAULT_ARCHIVE_FILTERS = Object.freeze({
+  driverId: 'all',
+  merchandise: 'all',
+  period: 'week',
+  from: null,
+  to: null,
+});
+
 const state = {
   driverSearchResults: [],
   adminDrivers: [],
@@ -20,17 +40,8 @@ const state = {
   currentUser: null,
   isAdmin: false,
   admins: [],
-  adminFilters: {
-    driverId: 'all',
-    range: 'week',
-  },
-  archiveFilters: {
-    driverId: 'all',
-    merchandise: 'all',
-    period: 'week',
-    from: null,
-    to: null,
-  },
+  adminFilters: { ...DEFAULT_ADMIN_FILTERS },
+  archiveFilters: { ...DEFAULT_ARCHIVE_FILTERS },
   adminView: 'planning',
   currentCourseId: null,
   photoDataUrl: null,
@@ -38,6 +49,7 @@ const state = {
   pendingDriverLogin: null,
   driverPasswordError: '',
   activeDriverTab: 'today',
+  cameraFacingMode: 'environment',
   driverManagement: {
     expanded: false,
     loading: false,
@@ -69,7 +81,15 @@ const state = {
   },
   adminManagementView: 'list',
   adminEdit: { ...ADMIN_EDIT_DEFAULT },
+  displayPreferences: {
+    driverLayout: 'cards',
+    driverDensity: 'comfortable',
+    adminLayout: 'table',
+    adminDensity: 'comfortable',
+  },
 };
+
+let adminSearchTimer = null;
 
 const elements = {
   loginPage: document.getElementById('login-page'),
@@ -95,11 +115,23 @@ const elements = {
   weekList: document.getElementById('week-list'),
   adminDriverSelect: document.getElementById('admin-driver-select'),
   adminWeekList: document.getElementById('admin-week-list'),
+  adminTableWrapper: document.getElementById('admin-table-wrapper'),
+  adminCardList: document.getElementById('admin-card-list'),
   noCoursesAdmin: document.getElementById('no-courses-admin'),
   activityLogList: document.getElementById('activity-log'),
   noActivity: document.getElementById('no-activity'),
   newCourseAdminBtn: document.getElementById('new-course-admin'),
   adminRangeButtons: document.querySelectorAll('[data-admin-range]'),
+  adminStatusFilter: document.getElementById('admin-status-filter'),
+  adminMerchandiseFilter: document.getElementById('admin-merchandise-filter'),
+  adminSearchFilter: document.getElementById('admin-search-filter'),
+  adminIssueFilter: document.getElementById('admin-issue-filter'),
+  adminPhotoFilter: document.getElementById('admin-photo-filter'),
+  adminFromInput: document.getElementById('admin-from'),
+  adminToInput: document.getElementById('admin-to'),
+  adminResetFiltersBtn: document.getElementById('admin-reset-filters'),
+  adminExportPdfBtn: document.getElementById('admin-export-pdf'),
+  adminExportExcelBtn: document.getElementById('admin-export-excel'),
   addCourseForm: document.getElementById('add-course-form'),
   adminDriverField: document.getElementById('admin-driver-field'),
   adminDriverPicker: document.getElementById('admin-driver-picker'),
@@ -125,6 +157,8 @@ const elements = {
   captureBtn: document.getElementById('capture-btn'),
   confirmPhotoBtn: document.getElementById('confirm-photo'),
   retakePhotoBtn: document.getElementById('retake-photo'),
+  switchCameraBtn: document.getElementById('switch-camera'),
+  cameraFacingSelect: document.getElementById('camera-facing-select'),
   courseEditorModal: document.getElementById('course-editor-modal'),
   courseEditorTitle: document.getElementById('course-editor-title'),
   courseEditorForm: document.getElementById('course-editor-form'),
@@ -208,6 +242,12 @@ const elements = {
   adminPasswordCurrent: document.getElementById('admin-password-current'),
   adminPasswordNew: document.getElementById('admin-password-new'),
   adminPasswordFeedback: document.getElementById('admin-password-feedback'),
+  driverLayoutButtons: document.querySelectorAll('[data-driver-layout]'),
+  driverDensityButtons: document.querySelectorAll('[data-driver-density]'),
+  adminLayoutButtons: document.querySelectorAll('[data-admin-layout]'),
+  adminDensityButtons: document.querySelectorAll('[data-admin-density]'),
+  archiveExportPdfBtn: document.getElementById('archive-export-pdf'),
+  archiveExportExcelBtn: document.getElementById('archive-export-excel'),
 };
 
 let eventSource = null;
@@ -402,6 +442,38 @@ function computeAdminIdentifier(firstName, lastName) {
   return `${trimmedFirst.charAt(0)}${trimmedLast}`.toLowerCase();
 }
 
+function applyDisplayPreferences() {
+  if (elements.driverDashboard) {
+    elements.driverDashboard.dataset.courseLayout = state.displayPreferences.driverLayout;
+    elements.driverDashboard.dataset.courseDensity = state.displayPreferences.driverDensity;
+  }
+
+  if (elements.adminDashboard) {
+    elements.adminDashboard.dataset.courseLayout = state.displayPreferences.adminLayout;
+    elements.adminDashboard.dataset.courseDensity = state.displayPreferences.adminDensity;
+  }
+
+  elements.driverLayoutButtons?.forEach((button) => {
+    const isActive = button.dataset.driverLayout === state.displayPreferences.driverLayout;
+    button.classList.toggle('filter-chip--active', isActive);
+  });
+
+  elements.driverDensityButtons?.forEach((button) => {
+    const isActive = button.dataset.driverDensity === state.displayPreferences.driverDensity;
+    button.classList.toggle('filter-chip--active', isActive);
+  });
+
+  elements.adminLayoutButtons?.forEach((button) => {
+    const isActive = button.dataset.adminLayout === state.displayPreferences.adminLayout;
+    button.classList.toggle('filter-chip--active', isActive);
+  });
+
+  elements.adminDensityButtons?.forEach((button) => {
+    const isActive = button.dataset.adminDensity === state.displayPreferences.adminDensity;
+    button.classList.toggle('filter-chip--active', isActive);
+  });
+}
+
 function formatAdminLevel(role) {
   if (role === 'superadmin') {
     return 'Super admin';
@@ -468,7 +540,7 @@ function renderDriverList(drivers) {
 }
 
 async function loginAsDriver(driver, options = {}) {
-  const { skipPasswordCheck = false, initialTab = 'today' } = options;
+  const { skipPasswordCheck = false, initialTab = 'today', displayPreferences = null } = options;
   const normalizedDriver = normalizeDriver(driver);
 
   if (!skipPasswordCheck && normalizedDriver.hasPassword) {
@@ -490,6 +562,13 @@ async function loginAsDriver(driver, options = {}) {
   hideElement(elements.adminDashboard);
   closeDriverPasswordModal();
   state.activeDriverTab = initialTab;
+  if (displayPreferences) {
+    state.displayPreferences = {
+      ...state.displayPreferences,
+      ...displayPreferences,
+    };
+  }
+  applyDisplayPreferences();
   switchTab(initialTab);
   await loadDriverCourses();
   updateMessagingAvailability();
@@ -596,11 +675,13 @@ async function handleDriverPasswordPrompt(password) {
 
 function setAdminSession(admin, options = {}) {
   const normalized = normalizeAdmin(admin);
-  const defaultAdminFilters = { driverId: 'all', range: 'week' };
-  const defaultArchiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
   const view = options.view || options.adminView || 'planning';
   const driverTab = options.driverTab || options.activeDriverTab || 'week';
   const settingsTab = options.settingsTab || 'email';
+  const displayPreferences = {
+    ...state.displayPreferences,
+    ...(options.displayPreferences || {}),
+  };
 
   state.currentUser = {
     ...normalized,
@@ -609,8 +690,9 @@ function setAdminSession(admin, options = {}) {
     token: admin.token || state.currentUser?.token || null,
   };
   state.isAdmin = true;
-  state.adminFilters = { ...defaultAdminFilters, ...(options.adminFilters || {}) };
-  state.archiveFilters = { ...defaultArchiveFilters, ...(options.archiveFilters || {}) };
+  state.adminFilters = { ...DEFAULT_ADMIN_FILTERS, ...(options.adminFilters || {}) };
+  state.archiveFilters = { ...DEFAULT_ARCHIVE_FILTERS, ...(options.archiveFilters || {}) };
+  state.displayPreferences = displayPreferences;
   state.settings = {
     emailRecipient: '',
     loaded: false,
@@ -630,6 +712,9 @@ function setAdminSession(admin, options = {}) {
   hideElement(elements.driverDashboard);
   showElement(elements.adminDashboard);
   closeAdminLoginModal();
+
+  applyDisplayPreferences();
+  syncAdminFiltersToInputs();
 
   if (elements.adminIdentifierDisplay) {
     const levelLabel =
@@ -1307,6 +1392,7 @@ function updateAdminRangeButtons() {
       button.classList.remove('filter-chip--active');
     }
   });
+  updateAdminDateInputs();
 }
 
 function renderSettingsTabs() {
@@ -1594,8 +1680,7 @@ async function unarchiveCourse(courseId) {
   }
 }
 
-async function loadAdminCourses() {
-  const params = new URLSearchParams();
+function resolveAdminRange() {
   const today = startOfDay(new Date());
   let from = null;
   let to = null;
@@ -1606,13 +1691,77 @@ async function loadAdminCourses() {
       to = addDays(today, 1);
       break;
     case 'week':
-      from = addDays(today, -7);
-      to = addDays(today, 7);
+      from = addDays(today, -3);
+      to = addDays(today, 4);
       break;
-    case 'all':
+    case 'month': {
+      const start = new Date(today);
+      start.setDate(1);
+      from = startOfDay(start);
+      const end = new Date(start);
+      end.setMonth(end.getMonth() + 1);
+      to = startOfDay(end);
+      break;
+    }
+    case 'custom': {
+      if (state.adminFilters.from) {
+        const start = startOfDay(new Date(state.adminFilters.from));
+        if (!Number.isNaN(start.getTime())) {
+          from = start;
+        }
+      }
+      if (state.adminFilters.to) {
+        const end = startOfDay(new Date(state.adminFilters.to));
+        if (!Number.isNaN(end.getTime())) {
+          to = addDays(end, 1);
+        }
+      }
+      break;
+    }
     default:
       break;
   }
+
+  return { from, to };
+}
+
+function updateAdminDateInputs() {
+  const isCustom = state.adminFilters.range === 'custom';
+  if (elements.adminFromInput) {
+    elements.adminFromInput.disabled = !isCustom;
+    elements.adminFromInput.value = isCustom && state.adminFilters.from ? state.adminFilters.from : '';
+  }
+  if (elements.adminToInput) {
+    elements.adminToInput.disabled = !isCustom;
+    elements.adminToInput.value = isCustom && state.adminFilters.to ? state.adminFilters.to : '';
+  }
+}
+
+function syncAdminFiltersToInputs() {
+  if (elements.adminDriverSelect) {
+    elements.adminDriverSelect.value = state.adminFilters.driverId || 'all';
+  }
+  if (elements.adminStatusFilter) {
+    elements.adminStatusFilter.value = state.adminFilters.status || 'all';
+  }
+  if (elements.adminMerchandiseFilter) {
+    elements.adminMerchandiseFilter.value = state.adminFilters.merchandise || 'all';
+  }
+  if (elements.adminIssueFilter) {
+    elements.adminIssueFilter.value = state.adminFilters.issue || 'all';
+  }
+  if (elements.adminPhotoFilter) {
+    elements.adminPhotoFilter.value = state.adminFilters.hasPhoto || 'all';
+  }
+  if (elements.adminSearchFilter) {
+    elements.adminSearchFilter.value = state.adminFilters.search || '';
+  }
+  updateAdminRangeButtons();
+}
+
+async function loadAdminCourses() {
+  const params = new URLSearchParams();
+  const { from, to } = resolveAdminRange();
 
   if (from) {
     params.append('from', from.toISOString());
@@ -1625,12 +1774,262 @@ async function loadAdminCourses() {
     params.append('driverId', state.adminFilters.driverId);
   }
 
+  if (state.adminFilters.status && state.adminFilters.status !== 'all') {
+    params.append('status', state.adminFilters.status);
+  }
+
+  if (state.adminFilters.merchandise && state.adminFilters.merchandise !== 'all') {
+    params.append('merchandise', state.adminFilters.merchandise);
+  }
+
+  if (state.adminFilters.issue === 'issues') {
+    params.append('issue', 'reported');
+  } else if (state.adminFilters.issue === 'clear') {
+    params.append('issue', 'none');
+  }
+
+  if (state.adminFilters.hasPhoto === 'with') {
+    params.append('hasPhoto', 'true');
+  } else if (state.adminFilters.hasPhoto === 'without') {
+    params.append('hasPhoto', 'false');
+  }
+
+  if (state.adminFilters.search) {
+    params.append('search', state.adminFilters.search);
+  }
+
   try {
     const courses = await apiFetch(`/courses?${params.toString()}`);
     state.adminCourses = courses.map(mapCourse);
     renderAdminCourses();
   } catch (error) {
     console.error('Erreur lors du chargement des courses', error);
+  }
+}
+
+function handleAdminRangeClick(event) {
+  const button = event.target.closest('[data-admin-range]');
+  if (!button) {
+    return;
+  }
+  const range = button.getAttribute('data-admin-range') || 'all';
+  state.adminFilters.range = range;
+  if (range !== 'custom') {
+    state.adminFilters.from = null;
+    state.adminFilters.to = null;
+  }
+  updateAdminRangeButtons();
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function handleAdminStatusChange() {
+  if (!elements.adminStatusFilter) {
+    return;
+  }
+  state.adminFilters.status = elements.adminStatusFilter.value || 'all';
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function handleAdminMerchandiseChange() {
+  if (!elements.adminMerchandiseFilter) {
+    return;
+  }
+  state.adminFilters.merchandise = elements.adminMerchandiseFilter.value || 'all';
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function handleAdminIssueChange() {
+  if (!elements.adminIssueFilter) {
+    return;
+  }
+  state.adminFilters.issue = elements.adminIssueFilter.value || 'all';
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function handleAdminPhotoChange() {
+  if (!elements.adminPhotoFilter) {
+    return;
+  }
+  state.adminFilters.hasPhoto = elements.adminPhotoFilter.value || 'all';
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function handleAdminDateChange() {
+  if (!elements.adminFromInput || !elements.adminToInput) {
+    return;
+  }
+  if (state.adminFilters.range !== 'custom') {
+    state.adminFilters.range = 'custom';
+  }
+  state.adminFilters.from = elements.adminFromInput.value || null;
+  state.adminFilters.to = elements.adminToInput.value || null;
+  updateAdminRangeButtons();
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function scheduleAdminSearch() {
+  if (adminSearchTimer) {
+    clearTimeout(adminSearchTimer);
+  }
+  adminSearchTimer = setTimeout(() => {
+    loadAdminCourses();
+    persistSessionState();
+  }, 300);
+}
+
+function handleAdminSearchInput(event) {
+  state.adminFilters.search = event.target.value.trim();
+  scheduleAdminSearch();
+}
+
+function resetAdminFilters() {
+  state.adminFilters = { ...DEFAULT_ADMIN_FILTERS };
+  syncAdminFiltersToInputs();
+  loadAdminCourses();
+  persistSessionState();
+}
+
+function handleDriverLayoutChange(event) {
+  const layout = event.target.getAttribute('data-driver-layout');
+  if (!layout) {
+    return;
+  }
+  state.displayPreferences.driverLayout = layout;
+  applyDisplayPreferences();
+  renderTodayCourses();
+  renderWeekCourses();
+  persistSessionState();
+}
+
+function handleDriverDensityChange(event) {
+  const density = event.target.getAttribute('data-driver-density');
+  if (!density) {
+    return;
+  }
+  state.displayPreferences.driverDensity = density;
+  applyDisplayPreferences();
+  renderTodayCourses();
+  renderWeekCourses();
+  persistSessionState();
+}
+
+function handleAdminLayoutChange(event) {
+  const layout = event.target.getAttribute('data-admin-layout');
+  if (!layout) {
+    return;
+  }
+  state.displayPreferences.adminLayout = layout;
+  applyDisplayPreferences();
+  renderAdminCourses();
+  persistSessionState();
+}
+
+function handleAdminDensityChange(event) {
+  const density = event.target.getAttribute('data-admin-density');
+  if (!density) {
+    return;
+  }
+  state.displayPreferences.adminDensity = density;
+  applyDisplayPreferences();
+  renderAdminCourses();
+  persistSessionState();
+}
+
+async function exportCourses(format, context = 'planning') {
+  if (!state.isAdmin || !state.currentUser?.token) {
+    alert('Seul un administrateur connecté peut exporter les courses.');
+    return;
+  }
+
+  const params = new URLSearchParams();
+  params.append('format', format);
+
+  if (context === 'archives') {
+    params.append('archived', 'true');
+    if (state.archiveFilters.driverId && state.archiveFilters.driverId !== 'all') {
+      params.append('driverId', state.archiveFilters.driverId);
+    }
+    if (state.archiveFilters.merchandise && state.archiveFilters.merchandise !== 'all') {
+      params.append('merchandise', state.archiveFilters.merchandise);
+    }
+    const { from, to } = resolveArchiveRange();
+    if (from) {
+      params.append('from', from.toISOString());
+    }
+    if (to) {
+      params.append('to', to.toISOString());
+    }
+  } else {
+    const { from, to } = resolveAdminRange();
+    if (from) {
+      params.append('from', from.toISOString());
+    }
+    if (to) {
+      params.append('to', to.toISOString());
+    }
+    if (state.adminFilters.driverId && state.adminFilters.driverId !== 'all') {
+      params.append('driverId', state.adminFilters.driverId);
+    }
+    if (state.adminFilters.status && state.adminFilters.status !== 'all') {
+      params.append('status', state.adminFilters.status);
+    }
+    if (state.adminFilters.merchandise && state.adminFilters.merchandise !== 'all') {
+      params.append('merchandise', state.adminFilters.merchandise);
+    }
+    if (state.adminFilters.issue === 'issues') {
+      params.append('issue', 'reported');
+    } else if (state.adminFilters.issue === 'clear') {
+      params.append('issue', 'none');
+    }
+    if (state.adminFilters.hasPhoto === 'with') {
+      params.append('hasPhoto', 'true');
+    } else if (state.adminFilters.hasPhoto === 'without') {
+      params.append('hasPhoto', 'false');
+    }
+    if (state.adminFilters.search) {
+      params.append('search', state.adminFilters.search);
+    }
+  }
+
+  try {
+    const response = await fetch(`${API_BASE}/courses/export?${params.toString()}`, {
+      headers: {
+        'X-Admin-Token': state.currentUser.token,
+      },
+    });
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.message || "Impossible de générer l'export." );
+    }
+
+    const blob = await response.blob();
+    let filename = format === 'pdf' ? 'export-courses.pdf' : 'export-courses.xlsx';
+    const disposition = response.headers.get('content-disposition');
+    if (disposition) {
+      const match = /filename="?([^";]+)"?/i.exec(disposition);
+      if (match && match[1]) {
+        filename = match[1];
+      }
+    }
+
+    const downloadUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(() => URL.revokeObjectURL(downloadUrl), 1500);
+  } catch (error) {
+    console.error("Erreur lors de l'export", error);
+    alert(error.message || "Impossible de générer l'export.");
   }
 }
 
@@ -2188,54 +2587,104 @@ function renderTodayCourses() {
 
   hideElement(elements.noCoursesToday);
 
+  const layout = state.displayPreferences.driverLayout || 'cards';
+  const commentsClass = state.displayPreferences.driverDensity === 'contrast' ? 'text-gray-800 font-medium' : 'text-gray-600';
+
+  if (layout === 'list') {
+    elements.todayList.className = 'today-list divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white';
+  } else {
+    elements.todayList.className = 'today-list space-y-3';
+  }
+
   courses
     .sort((a, b) => a.date.getTime() - b.date.getTime())
     .forEach((course) => {
       const container = document.createElement('div');
       const archived = course.isArchived;
-      const baseClasses = 'course-item bg-white p-4 rounded-lg shadow-sm border border-gray-200 transition';
-      container.className = `${baseClasses} ${archived ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`;
-      container.setAttribute('aria-disabled', archived ? 'true' : 'false');
-
+      const departure = escapeHtml(course.departure || '');
+      const destination = escapeHtml(course.destination || '');
+      const merchandise = escapeHtml(course.merchandise || '');
+      const comments = course.comments ? escapeHtml(course.comments) : '';
+      const issueComment = course.issueReportComment ? escapeHtml(course.issueReportComment) : '';
       const statusMeta = getCourseStatusMeta(course);
 
-      container.innerHTML = `
-        <div class="flex justify-between items-start">
-          <div>
-            <div class="font-medium">${course.departure} → ${course.destination}</div>
-            <div class="text-sm text-gray-500 mt-1">${formatTime(course.date)} • ${course.merchandise}</div>
+      if (layout === 'list') {
+        container.className = `course-item course-item--list px-4 py-3 ${
+          archived ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'
+        }`;
+        container.setAttribute('aria-disabled', archived ? 'true' : 'false');
+        container.innerHTML = `
+          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 w-full">
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-gray-800 truncate">${departure} → ${destination}</div>
+              <div class="text-sm text-gray-500 mt-1">${formatTime(course.date)} • ${merchandise || '—'}</div>
+              ${comments ? `<div class="mt-2 text-sm ${commentsClass}"><i class="fas fa-comment mr-1"></i> ${comments}</div>` : ''}
+              ${course.status === 'issue_reported' && issueComment
+                ? `<div class="mt-2 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2">Problème signalé : ${issueComment}</div>`
+                : ''}
+            </div>
+            <div class="flex flex-col items-stretch sm:items-end gap-2 min-w-[150px]">
+              <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className} text-center">${statusMeta.label}</span>
+              ${
+                !archived && course.status !== 'completed' && course.status !== 'issue_reported'
+                  ? '<button type="button" class="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 issue-toggle"><i class="fas fa-exclamation-triangle mr-2"></i>Signaler</button>'
+                  : ''
+              }
+            </div>
           </div>
-          <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">
-            ${statusMeta.label}
-          </span>
-        </div>
-        ${course.comments ? `<div class="mt-2 text-sm text-gray-600"><i class="fas fa-comment mr-1"></i> ${course.comments}</div>` : ''}
-      `;
+        `;
+      } else {
+        const baseClasses = 'course-item bg-white p-4 rounded-lg shadow-sm border border-gray-200 transition';
+        container.className = `${baseClasses} ${archived ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`;
+        container.setAttribute('aria-disabled', archived ? 'true' : 'false');
+        container.innerHTML = `
+          <div class="flex justify-between items-start">
+            <div>
+              <div class="font-medium">${departure} → ${destination}</div>
+              <div class="text-sm text-gray-500 mt-1">${formatTime(course.date)} • ${merchandise || '—'}</div>
+            </div>
+            <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">
+              ${statusMeta.label}
+            </span>
+          </div>
+          ${comments ? `<div class="mt-2 text-sm ${commentsClass}"><i class="fas fa-comment mr-1"></i> ${comments}</div>` : ''}
+        `;
+
+        if (course.status === 'issue_reported' && issueComment) {
+          const issueNotice = document.createElement('div');
+          issueNotice.className = 'mt-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2';
+          issueNotice.textContent = `Problème signalé : ${issueComment || 'Détail non renseigné'}`;
+          container.appendChild(issueNotice);
+        }
+
+        if (!archived && course.status !== 'completed' && course.status !== 'issue_reported') {
+          const buttonWrapper = document.createElement('div');
+          buttonWrapper.className = 'mt-3 flex justify-end';
+          const issueButton = document.createElement('button');
+          issueButton.type = 'button';
+          issueButton.className = 'inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 issue-toggle';
+          issueButton.innerHTML = '<i class="fas fa-exclamation-triangle mr-2"></i>Signaler un problème';
+          issueButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openCourseIssueModal(course.id);
+          });
+          buttonWrapper.appendChild(issueButton);
+          container.appendChild(buttonWrapper);
+        }
+      }
 
       if (!archived) {
         container.addEventListener('click', () => openCourseModal(course.id));
       }
 
-      if (course.status === 'issue_reported' && course.issueReportComment) {
-        const issueNotice = document.createElement('div');
-        issueNotice.className = 'mt-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2';
-        issueNotice.textContent = `Problème signalé : ${course.issueReportComment || 'Détail non renseigné'}`;
-        container.appendChild(issueNotice);
-      }
-
-      if (!archived && course.status !== 'completed' && course.status !== 'issue_reported') {
-        const buttonWrapper = document.createElement('div');
-        buttonWrapper.className = 'mt-3 flex justify-end';
-        const issueButton = document.createElement('button');
-        issueButton.type = 'button';
-        issueButton.className = 'inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100';
-        issueButton.innerHTML = '<i class="fas fa-exclamation-triangle mr-2"></i>Signaler un problème';
-        issueButton.addEventListener('click', (event) => {
-          event.stopPropagation();
-          openCourseIssueModal(course.id);
-        });
-        buttonWrapper.appendChild(issueButton);
-        container.appendChild(buttonWrapper);
+      if (layout === 'list') {
+        const issueButton = container.querySelector('.issue-toggle');
+        if (issueButton) {
+          issueButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openCourseIssueModal(course.id);
+          });
+        }
       }
 
       elements.todayList.appendChild(container);
@@ -2258,17 +2707,21 @@ function renderWeekCourses() {
     .forEach((course) => {
       const row = document.createElement('tr');
       const archived = course.isArchived;
-      row.className = `${archived ? 'bg-gray-100 text-gray-500 cursor-not-allowed' : 'hover:bg-gray-50 cursor-pointer'}`;
+      row.className = `${archived ? 'bg-gray-100 text-gray-500 cursor-not-allowed' : 'hover:bg-gray-50 cursor-pointer'} driver-week-row`;
       row.setAttribute('aria-disabled', archived ? 'true' : 'false');
 
       const statusMeta = getCourseStatusMeta(course, {
         archivedClass: 'bg-gray-300 text-gray-700',
       });
+      const dateLabel = formatDate(course.date);
+      const departure = escapeHtml(course.departure || '');
+      const destination = escapeHtml(course.destination || '');
+      const issueText = course.issueReportComment ? escapeHtml(course.issueReportComment) : '';
 
       row.innerHTML = `
-        <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Date">${formatDate(course.date)}</td>
-        <td class="px-6 py-4 text-sm" data-label="Départ">${course.departure}</td>
-        <td class="px-6 py-4 text-sm" data-label="Arrivée">${course.destination}</td>
+        <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Date">${dateLabel}</td>
+        <td class="px-6 py-4 text-sm" data-label="Départ">${departure}</td>
+        <td class="px-6 py-4 text-sm" data-label="Arrivée">${destination}</td>
         <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Horaire">${formatTime(course.date)}</td>
         <td class="px-6 py-4" data-label="Statut">
           <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -2292,8 +2745,8 @@ function renderWeekCourses() {
         const cell = document.createElement('td');
         cell.colSpan = 5;
         cell.className = 'px-6 py-3 text-sm text-red-700 border-t border-red-100';
-        const issueText = course.issueReportComment || 'Détail non renseigné';
-        cell.innerHTML = `<i class="fas fa-circle-exclamation mr-2"></i>Problème signalé : ${escapeHtml(issueText)}`;
+        const issueLabel = issueText || 'Détail non renseigné';
+        cell.innerHTML = `<i class="fas fa-circle-exclamation mr-2"></i>Problème signalé : ${issueLabel}`;
         detailRow.appendChild(cell);
         elements.weekList.appendChild(row);
         elements.weekList.appendChild(detailRow);
@@ -2314,29 +2767,108 @@ function renderWeekCourses() {
 function renderAdminCourses() {
   elements.adminWeekList.innerHTML = '';
 
+  if (elements.adminCardList) {
+    elements.adminCardList.innerHTML = '';
+  }
+
   if (!state.adminCourses.length) {
     showElement(elements.noCoursesAdmin);
+    if (elements.adminCardList) {
+      hideElement(elements.adminCardList);
+    }
     return;
   }
 
   hideElement(elements.noCoursesAdmin);
 
+  const layout = state.displayPreferences.adminLayout || 'table';
+  if (layout === 'cards' && elements.adminCardList) {
+    hideElement(elements.adminTableWrapper);
+    showElement(elements.adminCardList);
+  } else {
+    showElement(elements.adminTableWrapper);
+    hideElement(elements.adminCardList);
+  }
+
   state.adminCourses
     .slice()
     .sort((a, b) => a.date.getTime() - b.date.getTime())
     .forEach((course) => {
-      const row = document.createElement('tr');
-      row.className = 'hover:bg-gray-50';
       const statusMeta = getCourseStatusMeta(course, {
         archivedClass: 'bg-gray-200 text-gray-600',
       });
+      const dateLabel = formatDate(course.date);
+      const timeLabel = formatTime(course.date);
+      const driverName = escapeHtml(course.driverName || '');
+      const departure = escapeHtml(course.departure || '');
+      const destination = escapeHtml(course.destination || '');
+      const merchandise = escapeHtml(course.merchandise || '');
+      const comments = course.comments ? escapeHtml(course.comments) : '';
+
+      if (layout === 'cards' && elements.adminCardList) {
+        const card = document.createElement('div');
+        card.className = 'admin-course-card bg-white border border-gray-200 rounded-lg p-4 shadow-sm';
+        card.innerHTML = `
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0 flex-1">
+              <div class="text-sm text-gray-500">${dateLabel} • ${timeLabel}</div>
+              <div class="font-semibold text-gray-900 mt-1">${driverName || '—'}</div>
+              <div class="text-sm text-gray-700 mt-2">${departure} → ${destination}</div>
+              <div class="text-xs text-gray-500 mt-1">${merchandise || '—'}</div>
+              ${comments ? `<div class="mt-2 text-sm text-gray-600"><i class="fas fa-comment mr-1"></i> ${comments}</div>` : ''}
+            </div>
+            <div class="flex flex-col items-end gap-2">
+              <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">${statusMeta.label}</span>
+              ${course.status === 'issue_reported'
+                ? '<span class="text-xs font-medium text-red-700"><i class="fas fa-circle-exclamation mr-1"></i>Problème en attente</span>'
+                : ''}
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-3 mt-4 justify-end" data-card-actions>
+            <button class="text-amber-600 hover:text-amber-800" data-action="archive" aria-label="Archiver la course">
+              <i class="fas fa-box-archive"></i>
+            </button>
+            <button class="text-blue-600 hover:text-blue-900" data-action="edit" aria-label="Modifier la course">
+              <i class="fas fa-edit"></i>
+            </button>
+            <button class="text-red-600 hover:text-red-900" data-action="delete" aria-label="Supprimer la course">
+              <i class="fas fa-trash"></i>
+            </button>
+          </div>
+        `;
+
+        const actions = card.querySelector('[data-card-actions]');
+        const archiveBtn = actions?.querySelector('[data-action="archive"]');
+        const editBtn = actions?.querySelector('[data-action="edit"]');
+        const deleteBtn = actions?.querySelector('[data-action="delete"]');
+
+        archiveBtn?.addEventListener('click', (event) => {
+          event.stopPropagation();
+          archiveCourse(course.id);
+        });
+        editBtn?.addEventListener('click', (event) => {
+          event.stopPropagation();
+          openCourseEditor(course);
+        });
+        deleteBtn?.addEventListener('click', (event) => {
+          event.stopPropagation();
+          deleteCourse(course.id);
+        });
+
+        card.addEventListener('click', () => openCourseModal(course.id));
+        elements.adminCardList.appendChild(card);
+        return;
+      }
+
+      const row = document.createElement('tr');
+      row.className = 'hover:bg-gray-50 admin-course-row';
 
       row.innerHTML = `
-        <td class="px-6 py-4 text-sm" data-label="Chauffeur">${course.driverName || ''}</td>
-        <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Date">${formatDate(course.date)}</td>
-        <td class="px-6 py-4 text-sm" data-label="Départ">${course.departure}</td>
-        <td class="px-6 py-4 text-sm" data-label="Arrivée">${course.destination}</td>
-        <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Horaire">${formatTime(course.date)}</td>
+        <td class="px-6 py-4 text-sm" data-label="Chauffeur">${driverName}</td>
+        <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Date">${dateLabel}</td>
+        <td class="px-6 py-4 text-sm" data-label="Départ">${departure}</td>
+        <td class="px-6 py-4 text-sm" data-label="Arrivée">${destination}</td>
+        <td class="px-6 py-4 text-sm sm:whitespace-nowrap" data-label="Horaire">${timeLabel}</td>
         <td class="px-6 py-4" data-label="Statut">
           <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <span class="px-2 py-1 text-xs rounded-full ${statusMeta.className}">
@@ -2363,19 +2895,20 @@ function renderAdminCourses() {
       `;
 
       row.addEventListener('click', (event) => {
-        const target = event.target.closest('button');
-        if (target && target.dataset.action === 'edit') {
+        const target = event.target.closest('button[data-action]');
+        if (target) {
           event.stopPropagation();
-          editCourse(course.id);
-        } else if (target && target.dataset.action === 'archive') {
-          event.stopPropagation();
-          archiveCourse(course.id);
-        } else if (target && target.dataset.action === 'delete') {
-          event.stopPropagation();
-          deleteCourse(course.id);
-        } else {
-          openCourseModal(course.id);
+          const action = target.dataset.action;
+          if (action === 'edit') {
+            editCourse(course.id);
+          } else if (action === 'archive') {
+            archiveCourse(course.id);
+          } else if (action === 'delete') {
+            deleteCourse(course.id);
+          }
+          return;
         }
+        openCourseModal(course.id);
       });
 
       elements.adminWeekList.appendChild(row);
@@ -2819,6 +3352,87 @@ function completeCourse(courseId) {
   openPhotoModal();
 }
 
+function stopCameraStream() {
+  if (elements.camera?.srcObject) {
+    elements.camera.srcObject.getTracks().forEach((track) => track.stop());
+    elements.camera.srcObject = null;
+  }
+}
+
+function updateCameraFacingSelect() {
+  if (elements.cameraFacingSelect) {
+    elements.cameraFacingSelect.value = state.cameraFacingMode;
+  }
+}
+
+async function startCameraStream({ fallback = true } = {}) {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    if (elements.photoPlaceholder) {
+      elements.photoPlaceholder.innerHTML = `
+        <i class="fas fa-camera-slash text-4xl mb-2"></i>
+        <p>Appareil photo non disponible sur cet appareil.</p>
+      `;
+      showElement(elements.photoPlaceholder);
+    }
+    return;
+  }
+
+  const desiredFacingMode = state.cameraFacingMode === 'user' ? 'user' : 'environment';
+  const constraints = { video: { facingMode: desiredFacingMode } };
+
+  stopCameraStream();
+  showElement(elements.photoPlaceholder);
+  hideElement(elements.camera);
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
+    elements.camera.srcObject = stream;
+    await elements.camera.play();
+    hideElement(elements.photoPlaceholder);
+    showElement(elements.camera);
+  } catch (error) {
+    console.warn('Accès caméra refusé ou indisponible avec facingMode', desiredFacingMode, error);
+    if (fallback && desiredFacingMode === 'environment') {
+      state.cameraFacingMode = 'user';
+      updateCameraFacingSelect();
+      persistSessionState();
+      await startCameraStream({ fallback: false });
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+      elements.camera.srcObject = stream;
+      await elements.camera.play();
+      state.cameraFacingMode = 'user';
+      updateCameraFacingSelect();
+      persistSessionState();
+      hideElement(elements.photoPlaceholder);
+      showElement(elements.camera);
+    } catch (innerError) {
+      console.error('Impossible de démarrer la caméra', innerError);
+      if (elements.photoPlaceholder) {
+        elements.photoPlaceholder.innerHTML = `
+          <i class="fas fa-camera-slash text-4xl mb-2"></i>
+          <p>Impossible d\'accéder à la caméra.</p>
+        `;
+        showElement(elements.photoPlaceholder);
+      }
+    }
+  }
+}
+
+function setCameraFacingMode(mode, { persist = true, restart = true } = {}) {
+  const normalized = mode === 'user' ? 'user' : 'environment';
+  state.cameraFacingMode = normalized;
+  updateCameraFacingSelect();
+  if (persist) {
+    persistSessionState();
+  }
+  if (restart) {
+    startCameraStream();
+  }
+}
+
 function openPhotoModal() {
   state.photoDataUrl = null;
   showElement(elements.photoModal);
@@ -2828,36 +3442,18 @@ function openPhotoModal() {
   hideElement(elements.confirmPhotoBtn);
   showElement(elements.captureBtn);
   showElement(elements.photoPlaceholder);
-
-  if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-    navigator.mediaDevices
-      .getUserMedia({ video: true })
-      .then((stream) => {
-        elements.camera.srcObject = stream;
-        elements.camera.play();
-        hideElement(elements.photoPlaceholder);
-        showElement(elements.camera);
-      })
-      .catch((error) => {
-        console.error('Accès caméra refusé', error);
-        elements.photoPlaceholder.innerHTML = `
-          <i class="fas fa-camera-slash text-4xl mb-2"></i>
-          <p>Impossible d'accéder à l'appareil photo</p>
-        `;
-      });
-  } else {
+  if (elements.photoPlaceholder) {
     elements.photoPlaceholder.innerHTML = `
-      <i class="fas fa-camera-slash text-4xl mb-2"></i>
-      <p>Appareil photo non disponible</p>
+      <i class="fas fa-camera text-4xl mb-2 text-green-600"></i>
+      <p>Initialisation de la caméra…</p>
     `;
   }
+  updateCameraFacingSelect();
+  startCameraStream();
 }
 
 function closePhotoModal() {
-  if (elements.camera.srcObject) {
-    elements.camera.srcObject.getTracks().forEach((track) => track.stop());
-    elements.camera.srcObject = null;
-  }
+  stopCameraStream();
 
   hideElement(elements.photoModal);
   state.photoDataUrl = null;
@@ -3478,15 +4074,23 @@ function capturePhoto() {
   showElement(elements.photoPreview);
   showElement(elements.retakePhotoBtn);
   showElement(elements.confirmPhotoBtn);
+  stopCameraStream();
 }
 
 function retakePhoto() {
   state.photoDataUrl = null;
-  showElement(elements.camera);
   hideElement(elements.photoPreview);
   hideElement(elements.retakePhotoBtn);
   hideElement(elements.confirmPhotoBtn);
   showElement(elements.captureBtn);
+  showElement(elements.photoPlaceholder);
+  if (elements.photoPlaceholder) {
+    elements.photoPlaceholder.innerHTML = `
+      <i class="fas fa-camera text-4xl mb-2 text-green-600"></i>
+      <p>Initialisation de la caméra…</p>
+    `;
+  }
+  startCameraStream();
 }
 
 async function confirmPhoto() {
@@ -3543,6 +4147,8 @@ function persistSessionState() {
   const session = {
     role: state.currentUser.role,
     activeDriverTab: state.activeDriverTab || 'today',
+    cameraFacingMode: state.cameraFacingMode,
+    displayPreferences: { ...state.displayPreferences },
   };
 
   if (state.currentUser.role === 'driver') {
@@ -3694,6 +4300,17 @@ async function restoreSessionFromStorage() {
     return;
   }
 
+  if (saved.displayPreferences) {
+    state.displayPreferences = {
+      ...state.displayPreferences,
+      ...saved.displayPreferences,
+    };
+  }
+
+  if (saved.cameraFacingMode) {
+    state.cameraFacingMode = saved.cameraFacingMode;
+  }
+
   if (saved.role === 'admin' && saved.token) {
     try {
       const response = await fetch(`${API_BASE}/admins/session`, {
@@ -3715,6 +4332,7 @@ async function restoreSessionFromStorage() {
         adminManagementView: saved.adminManagementView || 'list',
         adminFilters: saved.adminFilters || {},
         archiveFilters: saved.archiveFilters || {},
+        displayPreferences: saved.displayPreferences || {},
       });
       return;
     } catch (error) {
@@ -3731,6 +4349,7 @@ async function restoreSessionFromStorage() {
       await loginAsDriver(driver, {
         skipPasswordCheck: true,
         initialTab: saved.activeDriverTab || 'today',
+        displayPreferences: saved.displayPreferences || {},
       });
       return;
     } catch (error) {
@@ -3774,6 +4393,13 @@ function registerEventListeners() {
   elements.captureBtn.addEventListener('click', capturePhoto);
   elements.confirmPhotoBtn.addEventListener('click', confirmPhoto);
   elements.retakePhotoBtn.addEventListener('click', retakePhoto);
+  elements.switchCameraBtn?.addEventListener('click', () => {
+    const nextMode = state.cameraFacingMode === 'environment' ? 'user' : 'environment';
+    setCameraFacingMode(nextMode);
+  });
+  elements.cameraFacingSelect?.addEventListener('change', (event) => {
+    setCameraFacingMode(event.target.value || 'environment');
+  });
   elements.courseIssueForm?.addEventListener('submit', handleCourseIssueSubmit);
   elements.courseIssueCancel?.addEventListener('click', closeCourseIssueModal);
   elements.courseIssueClose?.addEventListener('click', closeCourseIssueModal);
@@ -3784,12 +4410,8 @@ function registerEventListeners() {
   elements.messagingThreadList?.addEventListener('click', handleMessagingThreadClick);
   elements.adminDriverSelect.addEventListener('change', () => {
     state.adminFilters.driverId = elements.adminDriverSelect.value || 'all';
-    if (state.isAdmin) {
-      loadAdminCourses();
-    }
-    if (state.currentUser?.role === 'admin') {
-      persistSessionState();
-    }
+    loadAdminCourses();
+    persistSessionState();
   });
   elements.newCourseAdminBtn.addEventListener('click', () => {
     openCourseEditor();
@@ -3800,17 +4422,50 @@ function registerEventListeners() {
 
   if (elements.adminRangeButtons) {
     elements.adminRangeButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        const range = button.getAttribute('data-admin-range');
-        state.adminFilters.range = range || 'week';
-        updateAdminRangeButtons();
-        loadAdminCourses();
-        if (state.currentUser?.role === 'admin') {
-          persistSessionState();
-        }
-      });
+      button.addEventListener('click', handleAdminRangeClick);
     });
   }
+
+  elements.adminStatusFilter?.addEventListener('change', handleAdminStatusChange);
+  elements.adminMerchandiseFilter?.addEventListener('change', handleAdminMerchandiseChange);
+  elements.adminIssueFilter?.addEventListener('change', handleAdminIssueChange);
+  elements.adminPhotoFilter?.addEventListener('change', handleAdminPhotoChange);
+  elements.adminFromInput?.addEventListener('change', handleAdminDateChange);
+  elements.adminToInput?.addEventListener('change', handleAdminDateChange);
+  elements.adminSearchFilter?.addEventListener('input', handleAdminSearchInput);
+  elements.adminResetFiltersBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    resetAdminFilters();
+  });
+  elements.adminExportPdfBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    exportCourses('pdf', state.adminView === 'archives' ? 'archives' : 'planning');
+  });
+  elements.adminExportExcelBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    exportCourses('xlsx', state.adminView === 'archives' ? 'archives' : 'planning');
+  });
+  elements.archiveExportPdfBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    exportCourses('pdf', 'archives');
+  });
+  elements.archiveExportExcelBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    exportCourses('xlsx', 'archives');
+  });
+
+  elements.driverLayoutButtons?.forEach((button) => {
+    button.addEventListener('click', handleDriverLayoutChange);
+  });
+  elements.driverDensityButtons?.forEach((button) => {
+    button.addEventListener('click', handleDriverDensityChange);
+  });
+  elements.adminLayoutButtons?.forEach((button) => {
+    button.addEventListener('click', handleAdminLayoutChange);
+  });
+  elements.adminDensityButtons?.forEach((button) => {
+    button.addEventListener('click', handleAdminDensityChange);
+  });
 
   elements.adminPlanningTab?.addEventListener('click', () => switchAdminView('planning'));
   elements.adminArchivesTab?.addEventListener('click', () => switchAdminView('archives'));
@@ -3887,6 +4542,7 @@ function init() {
   updateArchivePeriodInputs();
   renderDriverManagementPanel();
   renderSettingsTabs();
+  applyDisplayPreferences();
   registerEventListeners();
   setupRealtimeUpdates();
   resetMessagingState();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,14 @@
 const API_BASE = '/api';
 
+const ADMIN_EDIT_DEFAULT = Object.freeze({
+  id: null,
+  firstName: '',
+  lastName: '',
+  identifier: '',
+  role: 'standard',
+  saving: false,
+});
+
 const state = {
   driverSearchResults: [],
   adminDrivers: [],
@@ -45,6 +54,7 @@ const state = {
     saving: false,
     activeTab: 'email',
   },
+  adminEdit: { ...ADMIN_EDIT_DEFAULT },
 };
 
 const elements = {
@@ -630,6 +640,9 @@ async function loadAdmins() {
   try {
     const admins = await apiFetch('/admins');
     state.admins = admins.map(normalizeAdmin);
+    if (state.adminEdit.id && !state.admins.some((admin) => admin.id === state.adminEdit.id)) {
+      resetAdminEditState();
+    }
     renderAdminAccounts();
     renderAdminManagement();
   } catch (error) {
@@ -682,6 +695,78 @@ function renderAdminAccounts() {
   elements.adminAccountsList.appendChild(list);
 }
 
+function resetAdminEditState() {
+  Object.assign(state.adminEdit, ADMIN_EDIT_DEFAULT);
+}
+
+function startAdminEdit(admin) {
+  Object.assign(state.adminEdit, {
+    id: admin.id,
+    firstName: admin.firstName || '',
+    lastName: admin.lastName || '',
+    identifier: admin.identifier || '',
+    role: admin.role || 'standard',
+    saving: false,
+  });
+  renderAdminManagement();
+}
+
+function cancelAdminEdit() {
+  resetAdminEditState();
+  renderAdminManagement();
+}
+
+function updateAdminEditField(field, value) {
+  if (!state.adminEdit || state.adminEdit.id === null) {
+    return;
+  }
+  state.adminEdit[field] = value;
+}
+
+async function handleAdminUpdate(event, adminId) {
+  event.preventDefault();
+
+  if (state.adminEdit.id !== adminId) {
+    return;
+  }
+
+  const firstName = (state.adminEdit.firstName || '').trim();
+  const lastName = (state.adminEdit.lastName || '').trim();
+  const identifier = (state.adminEdit.identifier || '').trim();
+  const role = state.adminEdit.role || 'standard';
+
+  if (!firstName || !lastName || !identifier) {
+    setAdminManagementStatus('Veuillez renseigner prénom, nom et identifiant.', true);
+    return;
+  }
+
+  let finalMessage = '';
+  let isError = false;
+
+  try {
+    state.adminEdit.saving = true;
+    renderAdminManagement();
+    setAdminManagementStatus('Mise à jour du compte administrateur...');
+    await apiFetch(`/admins/${adminId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ firstName, lastName, identifier, role }),
+    });
+    await loadAdmins();
+    resetAdminEditState();
+    finalMessage = 'Administrateur mis à jour.';
+  } catch (error) {
+    console.error('Erreur lors de la mise à jour du compte administrateur', error);
+    finalMessage = error.message || 'Impossible de mettre à jour cet administrateur.';
+    isError = true;
+  } finally {
+    state.adminEdit.saving = false;
+    renderAdminManagement();
+    if (finalMessage) {
+      setAdminManagementStatus(finalMessage, isError);
+    }
+  }
+}
+
 function renderAdminManagement() {
   if (!elements.adminManagementSection) {
     return;
@@ -718,6 +803,146 @@ function renderAdminManagement() {
   list.className = 'space-y-3';
 
   state.admins.forEach((admin) => {
+    const isEditing = state.adminEdit.id === admin.id;
+
+    if (isEditing) {
+      const item = document.createElement('li');
+      item.className = 'border border-gray-200 rounded-md px-4 py-4 bg-white shadow-sm space-y-4';
+
+      const header = document.createElement('div');
+      header.className = 'flex flex-wrap items-center gap-2';
+      const title = document.createElement('div');
+      title.className = 'font-medium text-gray-800';
+      title.textContent = `Modifier ${admin.firstName} ${admin.lastName}`;
+      header.appendChild(title);
+
+      const roleBadge = document.createElement('span');
+      roleBadge.className =
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 text-xs';
+      roleBadge.textContent = formatAdminLevel(state.adminEdit.role || admin.role);
+      header.appendChild(roleBadge);
+
+      item.appendChild(header);
+
+      const form = document.createElement('form');
+      form.className = 'grid grid-cols-1 md:grid-cols-2 gap-3';
+      form.addEventListener('submit', (event) => handleAdminUpdate(event, admin.id));
+
+      const firstNameField = document.createElement('div');
+      const firstNameInputId = `admin-edit-first-${admin.id}`;
+      const firstNameLabel = document.createElement('label');
+      firstNameLabel.className = 'form-label';
+      firstNameLabel.setAttribute('for', firstNameInputId);
+      firstNameLabel.textContent = 'Prénom';
+      const firstNameInput = document.createElement('input');
+      firstNameInput.id = firstNameInputId;
+      firstNameInput.type = 'text';
+      firstNameInput.required = true;
+      firstNameInput.className = 'form-input';
+      firstNameInput.value = state.adminEdit.firstName;
+      firstNameInput.addEventListener('input', (event) => {
+        updateAdminEditField('firstName', event.target.value);
+      });
+      firstNameField.appendChild(firstNameLabel);
+      firstNameField.appendChild(firstNameInput);
+
+      const lastNameField = document.createElement('div');
+      const lastNameInputId = `admin-edit-last-${admin.id}`;
+      const lastNameLabel = document.createElement('label');
+      lastNameLabel.className = 'form-label';
+      lastNameLabel.setAttribute('for', lastNameInputId);
+      lastNameLabel.textContent = 'Nom';
+      const lastNameInput = document.createElement('input');
+      lastNameInput.id = lastNameInputId;
+      lastNameInput.type = 'text';
+      lastNameInput.required = true;
+      lastNameInput.className = 'form-input';
+      lastNameInput.value = state.adminEdit.lastName;
+      lastNameInput.addEventListener('input', (event) => {
+        updateAdminEditField('lastName', event.target.value);
+      });
+      lastNameField.appendChild(lastNameLabel);
+      lastNameField.appendChild(lastNameInput);
+
+      const identifierField = document.createElement('div');
+      identifierField.className = 'md:col-span-2';
+      const identifierInputId = `admin-edit-identifier-${admin.id}`;
+      const identifierLabel = document.createElement('label');
+      identifierLabel.className = 'form-label';
+      identifierLabel.setAttribute('for', identifierInputId);
+      identifierLabel.textContent = 'Identifiant de connexion';
+      const identifierInput = document.createElement('input');
+      identifierInput.id = identifierInputId;
+      identifierInput.type = 'text';
+      identifierInput.required = true;
+      identifierInput.className = 'form-input font-mono';
+      identifierInput.autocomplete = 'off';
+      identifierInput.value = state.adminEdit.identifier;
+      identifierInput.addEventListener('input', (event) => {
+        const sanitized = event.target.value.toLowerCase().replace(/[^a-z0-9._-]/g, '');
+        event.target.value = sanitized;
+        updateAdminEditField('identifier', sanitized);
+      });
+      const identifierHelp = document.createElement('p');
+      identifierHelp.className = 'text-xs text-gray-500 mt-1';
+      identifierHelp.textContent = 'Utilisé pour se connecter (lettres minuscules, chiffres, ".", "-", "_").';
+      identifierField.appendChild(identifierLabel);
+      identifierField.appendChild(identifierInput);
+      identifierField.appendChild(identifierHelp);
+
+      const roleField = document.createElement('div');
+      const roleSelectId = `admin-edit-role-${admin.id}`;
+      const roleLabel = document.createElement('label');
+      roleLabel.className = 'form-label';
+      roleLabel.setAttribute('for', roleSelectId);
+      roleLabel.textContent = "Niveau d'accès";
+      const roleSelect = document.createElement('select');
+      roleSelect.id = roleSelectId;
+      roleSelect.className = 'form-input';
+      ['manager', 'standard'].forEach((value) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = formatAdminLevel(value);
+        roleSelect.appendChild(option);
+      });
+      roleSelect.value = state.adminEdit.role || 'standard';
+      roleSelect.addEventListener('change', (event) => {
+        updateAdminEditField('role', event.target.value);
+        roleBadge.textContent = formatAdminLevel(event.target.value);
+      });
+      roleField.appendChild(roleLabel);
+      roleField.appendChild(roleSelect);
+
+      const actionsRow = document.createElement('div');
+      actionsRow.className = 'md:col-span-2 flex justify-end gap-2';
+      const cancelBtn = document.createElement('button');
+      cancelBtn.type = 'button';
+      cancelBtn.className = 'btn-secondary';
+      cancelBtn.textContent = 'Annuler';
+      cancelBtn.addEventListener('click', cancelAdminEdit);
+
+      const submitBtn = document.createElement('button');
+      submitBtn.type = 'submit';
+      submitBtn.className = 'btn-primary flex items-center';
+      submitBtn.disabled = state.adminEdit.saving;
+      submitBtn.innerHTML = state.adminEdit.saving
+        ? '<i class="fas fa-spinner fa-spin mr-2"></i>Enregistrement...'
+        : '<i class="fas fa-save mr-2"></i>Enregistrer';
+
+      actionsRow.appendChild(cancelBtn);
+      actionsRow.appendChild(submitBtn);
+
+      form.appendChild(firstNameField);
+      form.appendChild(lastNameField);
+      form.appendChild(identifierField);
+      form.appendChild(roleField);
+      form.appendChild(actionsRow);
+
+      item.appendChild(form);
+      list.appendChild(item);
+      return;
+    }
+
     const item = document.createElement('li');
     item.className =
       'border border-gray-200 rounded-md px-4 py-3 bg-white shadow-sm flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3';
@@ -732,7 +957,7 @@ function renderAdminManagement() {
     `;
 
     const actions = document.createElement('div');
-    actions.className = 'flex items-center gap-2';
+    actions.className = 'flex flex-wrap items-center gap-2';
 
     if (admin.identifier.toLowerCase() === 'lsaquet') {
       const badge = document.createElement('span');
@@ -740,6 +965,13 @@ function renderAdminManagement() {
       badge.textContent = 'Compte principal';
       actions.appendChild(badge);
     } else {
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'btn-secondary text-xs';
+      editBtn.textContent = 'Modifier';
+      editBtn.addEventListener('click', () => startAdminEdit(admin));
+      actions.appendChild(editBtn);
+
       const deleteBtn = document.createElement('button');
       deleteBtn.type = 'button';
       deleteBtn.className = 'btn-danger text-xs';
@@ -791,6 +1023,7 @@ async function logout(event) {
   state.driverManagement.error = null;
   state.activityLog = [];
   state.courseCache.clear();
+  resetAdminEditState();
   elements.lastnameInput.value = '';
   elements.driverList.innerHTML = '';
   hideElement(elements.driverDashboard);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,11 @@ const state = {
   currentCourseId: null,
   photoDataUrl: null,
   pendingCompletionComments: '',
+  settings: {
+    emailRecipient: '',
+    loaded: false,
+    saving: false,
+  },
 };
 
 const elements = {
@@ -112,8 +117,10 @@ const elements = {
   driverListContainer: document.getElementById('driver-management-list'),
   adminPlanningTab: document.getElementById('admin-planning-tab'),
   adminArchivesTab: document.getElementById('admin-archives-tab'),
+  adminSettingsTab: document.getElementById('admin-settings-tab'),
   adminPlanningView: document.getElementById('admin-planning-view'),
   adminArchiveView: document.getElementById('admin-archive-view'),
+  adminSettingsView: document.getElementById('admin-settings-view'),
   archiveDriverFilter: document.getElementById('archive-driver-filter'),
   archiveMerchandiseFilter: document.getElementById('archive-merchandise-filter'),
   archivePeriodFilter: document.getElementById('archive-period-filter'),
@@ -121,6 +128,9 @@ const elements = {
   archiveToInput: document.getElementById('archive-to'),
   archiveList: document.getElementById('archive-list'),
   noArchive: document.getElementById('no-archive'),
+  emailSettingsForm: document.getElementById('email-settings-form'),
+  emailRecipientInput: document.getElementById('email-recipient'),
+  emailSettingsStatus: document.getElementById('email-settings-status'),
 };
 
 function showElement(element) {
@@ -333,6 +343,7 @@ function setAdminSession(admin) {
   state.isAdmin = true;
   state.adminFilters = { driverId: 'all', range: 'week' };
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
+  state.settings = { emailRecipient: '', loaded: false, saving: false };
   updateArchivePeriodInputs();
 
   hideElement(elements.loginPage);
@@ -343,6 +354,11 @@ function setAdminSession(admin) {
   if (elements.adminIdentifierDisplay) {
     elements.adminIdentifierDisplay.textContent = `${state.currentUser.initials} (${state.currentUser.identifier})`;
   }
+
+  if (elements.emailRecipientInput) {
+    elements.emailRecipientInput.value = '';
+  }
+  resetEmailSettingsStatus();
 
   state.adminView = 'planning';
   switchAdminView('planning');
@@ -515,6 +531,7 @@ function logout() {
   state.archivedCourses = [];
   state.adminFilters = { driverId: 'all', range: 'week' };
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
+  state.settings = { emailRecipient: '', loaded: false, saving: false };
   state.activityLog = [];
   state.courseCache.clear();
   elements.lastnameInput.value = '';
@@ -543,6 +560,11 @@ function logout() {
   if (elements.archivePeriodFilter) {
     elements.archivePeriodFilter.value = 'week';
   }
+  if (elements.emailRecipientInput) {
+    elements.emailRecipientInput.value = '';
+  }
+  resetEmailSettingsStatus();
+  state.adminView = 'planning';
   updateAdminRangeButtons();
   updateArchivePeriodInputs();
   showElement(elements.loginPage);
@@ -581,28 +603,40 @@ function switchTab(tab) {
 function switchAdminView(view) {
   state.adminView = view;
 
-  if (!elements.adminPlanningView || !elements.adminArchiveView) {
-    return;
+  const configurations = [
+    { key: 'planning', tab: elements.adminPlanningTab, panel: elements.adminPlanningView },
+    { key: 'archives', tab: elements.adminArchivesTab, panel: elements.adminArchiveView },
+    { key: 'settings', tab: elements.adminSettingsTab, panel: elements.adminSettingsView },
+  ];
+
+  configurations.forEach(({ key, tab, panel }) => {
+    if (!tab || !panel) {
+      return;
+    }
+    if (key === view) {
+      showElement(panel);
+      tab.classList.add('admin-tab--active');
+    } else {
+      hideElement(panel);
+      tab.classList.remove('admin-tab--active');
+    }
+  });
+
+  if (view === 'planning') {
+    updateAdminRangeButtons();
   }
 
-  const planningActive = view === 'planning';
-
-  if (planningActive) {
-    showElement(elements.adminPlanningView);
-    hideElement(elements.adminArchiveView);
-    elements.adminPlanningTab?.classList.add('admin-tab--active');
-    elements.adminArchivesTab?.classList.remove('admin-tab--active');
-  } else {
-    hideElement(elements.adminPlanningView);
-    showElement(elements.adminArchiveView);
-    elements.adminArchivesTab?.classList.add('admin-tab--active');
-    elements.adminPlanningTab?.classList.remove('admin-tab--active');
+  if (view === 'archives') {
     updateArchivePeriodInputs();
     if (!state.archivedCourses.length) {
       loadArchivedCourses();
     } else {
       renderArchivedCourses();
     }
+  }
+
+  if (view === 'settings') {
+    loadEmailSettings();
   }
 }
 
@@ -1020,6 +1054,96 @@ function handleArchiveDatesChange() {
   state.archiveFilters.from = elements.archiveFromInput.value || null;
   state.archiveFilters.to = elements.archiveToInput.value || null;
   loadArchivedCourses();
+}
+
+function resetEmailSettingsStatus() {
+  if (!elements.emailSettingsStatus) {
+    return;
+  }
+  elements.emailSettingsStatus.textContent = '';
+  elements.emailSettingsStatus.classList.add('hidden');
+  elements.emailSettingsStatus.classList.remove('text-green-600', 'text-red-600');
+}
+
+function showEmailSettingsStatus(message, isError = false) {
+  if (!elements.emailSettingsStatus) {
+    return;
+  }
+  elements.emailSettingsStatus.textContent = message;
+  elements.emailSettingsStatus.classList.remove('hidden');
+  elements.emailSettingsStatus.classList.remove('text-green-600', 'text-red-600');
+  elements.emailSettingsStatus.classList.add(isError ? 'text-red-600' : 'text-green-600');
+}
+
+async function loadEmailSettings(force = false) {
+  if (!elements.emailRecipientInput) {
+    return;
+  }
+
+  if (state.settings.loaded && !force) {
+    elements.emailRecipientInput.value = state.settings.emailRecipient;
+    return;
+  }
+
+  try {
+    resetEmailSettingsStatus();
+    const response = await apiFetch('/settings/email-recipient');
+    state.settings.emailRecipient = response.email || '';
+    state.settings.loaded = true;
+    elements.emailRecipientInput.value = state.settings.emailRecipient;
+  } catch (error) {
+    console.error('Erreur lors du chargement de la configuration email', error);
+    showEmailSettingsStatus(error.message || "Impossible de charger l'adresse email.", true);
+  }
+}
+
+async function handleEmailSettingsSubmit(event) {
+  event.preventDefault();
+
+  if (!elements.emailRecipientInput) {
+    return;
+  }
+
+  if (state.settings.saving) {
+    return;
+  }
+
+  const email = elements.emailRecipientInput.value.trim();
+
+  if (!email) {
+    showEmailSettingsStatus('Veuillez renseigner une adresse email.', true);
+    return;
+  }
+
+  const submitButton = elements.emailSettingsForm?.querySelector('button[type="submit"]');
+
+  try {
+    state.settings.saving = true;
+    resetEmailSettingsStatus();
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.classList.add('opacity-50', 'cursor-not-allowed');
+    }
+
+    const response = await apiFetch('/settings/email-recipient', {
+      method: 'PUT',
+      body: JSON.stringify({ email }),
+    });
+
+    state.settings.emailRecipient = response.email || email;
+    state.settings.loaded = true;
+    elements.emailRecipientInput.value = state.settings.emailRecipient;
+    showEmailSettingsStatus('Adresse email mise à jour avec succès.');
+  } catch (error) {
+    console.error("Erreur lors de l'enregistrement de l'adresse email", error);
+    showEmailSettingsStatus(error.message || 'Impossible de mettre à jour cette adresse.', true);
+  } finally {
+    state.settings.saving = false;
+    if (submitButton) {
+      submitButton.disabled = false;
+      submitButton.classList.remove('opacity-50', 'cursor-not-allowed');
+    }
+  }
 }
 
 function renderTodayCourses() {
@@ -1762,6 +1886,7 @@ function registerEventListeners() {
 
   elements.adminPlanningTab?.addEventListener('click', () => switchAdminView('planning'));
   elements.adminArchivesTab?.addEventListener('click', () => switchAdminView('archives'));
+  elements.adminSettingsTab?.addEventListener('click', () => switchAdminView('settings'));
 
   elements.closeAdminLoginModalBtn?.addEventListener('click', closeAdminLoginModal);
   elements.adminLoginForm?.addEventListener('submit', handleAdminLogin);
@@ -1775,6 +1900,7 @@ function registerEventListeners() {
   elements.archiveMerchandiseFilter?.addEventListener('change', handleArchiveFiltersChange);
   elements.archiveFromInput?.addEventListener('change', handleArchiveDatesChange);
   elements.archiveToInput?.addEventListener('change', handleArchiveDatesChange);
+  elements.emailSettingsForm?.addEventListener('submit', handleEmailSettingsSubmit);
 
   window.addEventListener('click', (event) => {
     if (event.target === elements.courseModal) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,8 @@
 const API_BASE = '/api';
 
 const state = {
-  drivers: [],
+  driverSearchResults: [],
+  adminDrivers: [],
   driverCourses: [],
   adminCourses: [],
   archivedCourses: [],
@@ -29,6 +30,8 @@ const state = {
   driverPasswordError: '',
   driverManagement: {
     expanded: false,
+    loading: false,
+    error: null,
   },
   driverPasswordManagement: {
     drivers: [],
@@ -334,8 +337,8 @@ async function searchDrivers() {
 
   try {
     const drivers = await apiFetch(`/drivers?search=${encodeURIComponent(searchTerm)}`);
-    state.drivers = drivers.map(normalizeDriver);
-    renderDriverList(state.drivers);
+    state.driverSearchResults = drivers.map(normalizeDriver);
+    renderDriverList(state.driverSearchResults);
   } catch (error) {
     console.error(error);
     elements.driverList.innerHTML = '<p class="text-sm text-red-600">Erreur lors de la recherche</p>';
@@ -511,6 +514,10 @@ function setAdminSession(admin) {
   };
   state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
   state.driverManagement.expanded = false;
+  state.driverManagement.loading = false;
+  state.driverManagement.error = null;
+  state.adminDrivers = [];
+  state.driverSearchResults = [];
   updateArchivePeriodInputs();
 
   hideElement(elements.loginPage);
@@ -737,6 +744,8 @@ async function logout(event) {
 
   state.currentUser = null;
   state.isAdmin = false;
+  state.driverSearchResults = [];
+  state.adminDrivers = [];
   state.driverCourses = [];
   state.adminCourses = [];
   state.archivedCourses = [];
@@ -750,6 +759,8 @@ async function logout(event) {
   };
   state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
   state.driverManagement.expanded = false;
+  state.driverManagement.loading = false;
+  state.driverManagement.error = null;
   state.activityLog = [];
   state.courseCache.clear();
   elements.lastnameInput.value = '';
@@ -986,10 +997,18 @@ async function loadDriverCourses() {
   }
 }
 
-async function loadAdminDrivers() {
+async function loadAdminDrivers({ force = false } = {}) {
+  if (state.driverManagement.loading && !force) {
+    return;
+  }
+
+  state.driverManagement.loading = true;
+  state.driverManagement.error = null;
+  renderDriverManagement();
+
   try {
     const drivers = await apiFetch('/drivers');
-    state.drivers = drivers.map(normalizeDriver);
+    state.adminDrivers = drivers.map(normalizeDriver);
     const selectedDriverFilter = state.adminFilters.driverId || 'all';
 
     elements.adminDriverSelect.innerHTML = '<option value="all">Tous les chauffeurs</option>';
@@ -999,7 +1018,7 @@ async function loadAdminDrivers() {
       elements.archiveDriverFilter.innerHTML = '<option value="all">Tous les chauffeurs</option>';
     }
 
-    state.drivers.forEach((driver) => {
+    state.adminDrivers.forEach((driver) => {
       const label = `${driver.firstName} ${driver.lastName}`;
       const option = document.createElement('option');
       option.value = driver.id;
@@ -1022,10 +1041,12 @@ async function loadAdminDrivers() {
     if (elements.archiveDriverFilter) {
       elements.archiveDriverFilter.value = state.archiveFilters.driverId || 'all';
     }
-
-    renderDriverManagement();
   } catch (error) {
     console.error('Erreur lors du chargement des chauffeurs', error);
+    state.driverManagement.error = error.message || 'Impossible de récupérer les chauffeurs.';
+  } finally {
+    state.driverManagement.loading = false;
+    renderDriverManagement();
   }
 }
 
@@ -1036,7 +1057,23 @@ function renderDriverManagement() {
 
   elements.driverListContainer.innerHTML = '';
 
-  if (!state.drivers.length) {
+  if (state.driverManagement.loading) {
+    const loading = document.createElement('p');
+    loading.className = 'text-sm text-gray-500';
+    loading.textContent = 'Chargement des chauffeurs...';
+    elements.driverListContainer.appendChild(loading);
+    return;
+  }
+
+  if (state.driverManagement.error) {
+    const error = document.createElement('p');
+    error.className = 'text-sm text-red-600';
+    error.textContent = state.driverManagement.error;
+    elements.driverListContainer.appendChild(error);
+    return;
+  }
+
+  if (!state.adminDrivers.length) {
     const empty = document.createElement('p');
     empty.className = 'text-sm text-gray-500';
     empty.textContent = 'Aucun chauffeur enregistré.';
@@ -1047,7 +1084,7 @@ function renderDriverManagement() {
   const list = document.createElement('ul');
   list.className = 'divide-y divide-gray-200';
 
-  state.drivers.forEach((driver) => {
+  state.adminDrivers.forEach((driver) => {
     const item = document.createElement('li');
     item.className = 'flex items-center justify-between py-2';
     item.innerHTML = `
@@ -1085,7 +1122,7 @@ async function handleAddDriver(event) {
     });
 
     elements.driverManagementForm.reset();
-    await loadAdminDrivers();
+    await loadAdminDrivers({ force: true });
     await loadAdminCourses();
   } catch (error) {
     console.error('Erreur lors de l\'ajout du chauffeur', error);
@@ -1100,7 +1137,7 @@ async function handleDeleteDriver(driverId) {
 
   try {
     await apiFetch(`/drivers/${driverId}`, { method: 'DELETE' });
-    await loadAdminDrivers();
+    await loadAdminDrivers({ force: true });
     await loadAdminCourses();
     await loadArchivedCourses();
     await loadActivityLog();
@@ -2468,6 +2505,9 @@ function registerEventListeners() {
   elements.driverManagementToggle?.addEventListener('click', () => {
     state.driverManagement.expanded = !state.driverManagement.expanded;
     renderDriverManagementPanel();
+    if (state.driverManagement.expanded && !state.adminDrivers.length && !state.driverManagement.loading) {
+      loadAdminDrivers({ force: true });
+    }
   });
 
   elements.archivePeriodFilter?.addEventListener('change', handleArchivePeriodChange);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,5 +1,4 @@
 const API_BASE = '/api';
-const DEFAULT_GMAIL_REDIRECT_URI = 'http://localhost';
 
 const state = {
   drivers: [],
@@ -26,14 +25,21 @@ const state = {
   currentCourseId: null,
   photoDataUrl: null,
   pendingCompletionComments: '',
+  pendingDriverLogin: null,
+  driverPasswordError: '',
+  driverManagement: {
+    expanded: false,
+  },
+  driverPasswordManagement: {
+    drivers: [],
+    loading: false,
+    editingDriverId: null,
+  },
   settings: {
     emailRecipient: '',
-    gmailClientId: '',
-    gmailClientSecret: '',
-    gmailRefreshToken: '',
-    gmailRedirectUri: '',
     loaded: false,
     saving: false,
+    activeTab: 'email',
   },
 };
 
@@ -109,17 +115,19 @@ const elements = {
   adminIdentifierInput: document.getElementById('admin-identifier-input'),
   adminPasswordInput: document.getElementById('admin-password-input'),
   adminAccountsList: document.getElementById('admin-accounts'),
-  adminCreateForm: document.getElementById('admin-create-form'),
-  adminCreateFirstName: document.getElementById('admin-create-first-name'),
-  adminCreateLastName: document.getElementById('admin-create-last-name'),
-  adminCreatePassword: document.getElementById('admin-create-password'),
-  adminIdentifierPreview: document.getElementById('admin-identifier-preview'),
-  adminIdentifierPreviewValue: document.getElementById('admin-identifier-preview-value'),
+  driverPasswordModal: document.getElementById('driver-password-modal'),
+  driverPasswordForm: document.getElementById('driver-password-form'),
+  driverPasswordInput: document.getElementById('driver-password-input'),
+  driverPasswordCancel: document.getElementById('driver-password-cancel'),
+  driverPasswordError: document.getElementById('driver-password-error'),
+  driverPasswordName: document.getElementById('driver-password-name'),
   driverManagementForm: document.getElementById('driver-management-form'),
   driverFirstNameInput: document.getElementById('driver-first-name'),
   driverLastNameInput: document.getElementById('driver-last-name'),
   driverEmailInput: document.getElementById('driver-email'),
   driverListContainer: document.getElementById('driver-management-list'),
+  driverManagementToggle: document.getElementById('driver-management-toggle'),
+  driverManagementPanel: document.getElementById('driver-management-panel'),
   adminPlanningTab: document.getElementById('admin-planning-tab'),
   adminArchivesTab: document.getElementById('admin-archives-tab'),
   adminSettingsTab: document.getElementById('admin-settings-tab'),
@@ -135,11 +143,23 @@ const elements = {
   noArchive: document.getElementById('no-archive'),
   emailSettingsForm: document.getElementById('email-settings-form'),
   emailRecipientInput: document.getElementById('email-recipient'),
-  gmailClientIdInput: document.getElementById('gmail-client-id'),
-  gmailClientSecretInput: document.getElementById('gmail-client-secret'),
-  gmailRefreshTokenInput: document.getElementById('gmail-refresh-token'),
-  gmailRedirectUriInput: document.getElementById('gmail-redirect-uri'),
   emailSettingsStatus: document.getElementById('email-settings-status'),
+  settingsTabButtons: document.querySelectorAll('[data-settings-tab]'),
+  settingsPanels: document.querySelectorAll('[data-settings-panel]'),
+  driverPasswordList: document.getElementById('driver-password-list'),
+  driverPasswordEmpty: document.getElementById('driver-password-empty'),
+  adminManagementSection: document.getElementById('admin-management-panel'),
+  adminManagementList: document.getElementById('admin-management-list'),
+  adminManagementCreateForm: document.getElementById('admin-management-create-form'),
+  adminManagementFirstName: document.getElementById('admin-management-first-name'),
+  adminManagementLastName: document.getElementById('admin-management-last-name'),
+  adminManagementPassword: document.getElementById('admin-management-password'),
+  adminManagementRole: document.getElementById('admin-management-role'),
+  adminManagementStatus: document.getElementById('admin-management-status'),
+  adminPasswordForm: document.getElementById('admin-password-form'),
+  adminPasswordCurrent: document.getElementById('admin-password-current'),
+  adminPasswordNew: document.getElementById('admin-password-new'),
+  adminPasswordFeedback: document.getElementById('admin-password-feedback'),
 };
 
 function showElement(element) {
@@ -164,11 +184,17 @@ function setDefaultCourseDateTime() {
 }
 
 async function apiFetch(path, options = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {}),
+  };
+
+  if (state.currentUser?.role === 'admin' && state.currentUser?.token) {
+    headers['X-Admin-Token'] = state.currentUser.token;
+  }
+
   const config = {
-    headers: {
-      'Content-Type': 'application/json',
-      ...(options.headers || {}),
-    },
+    headers,
     ...options,
   };
 
@@ -192,6 +218,7 @@ function normalizeDriver(driver) {
     lastName: driver.last_name || driver.lastName,
     email: driver.email || null,
     phone: driver.phone || null,
+    hasPassword: Boolean(driver.has_password ?? driver.hasPassword ?? false),
   };
 }
 
@@ -205,6 +232,7 @@ function normalizeAdmin(admin) {
     identifier: admin.identifier,
     initials: admin.initials || computeInitials(firstName, lastName),
     createdAt: admin.created_at || admin.createdAt || null,
+    role: admin.role || 'standard',
   };
 }
 
@@ -275,6 +303,16 @@ function computeAdminIdentifier(firstName, lastName) {
   return `${trimmedFirst.charAt(0)}${trimmedLast}`.toLowerCase();
 }
 
+function formatAdminLevel(role) {
+  if (role === 'superadmin') {
+    return 'Super admin';
+  }
+  if (role === 'manager') {
+    return 'Gestion';
+  }
+  return 'Standard';
+}
+
 function getUserInitials() {
   if (state.currentUser?.initials) {
     return state.currentUser.initials;
@@ -319,7 +357,9 @@ function renderDriverList(drivers) {
     button.className = 'w-full text-left px-4 py-2 bg-gray-50 hover:bg-gray-100 rounded-md transition';
     button.innerHTML = `
       <div class="font-medium">${driver.firstName} ${driver.lastName}</div>
-      <div class="text-xs text-gray-500">Chauffeur</div>
+      <div class="text-xs text-gray-500 flex items-center gap-2">
+        ${driver.hasPassword ? '<i class="fas fa-lock text-green-600"></i><span>Mot de passe requis</span>' : '<span>Chauffeur</span>'}
+      </div>
     `;
     button.addEventListener('click', () => loginAsDriver(driver));
     elements.driverList.appendChild(button);
@@ -328,19 +368,128 @@ function renderDriverList(drivers) {
   showElement(elements.driverResults);
 }
 
-async function loginAsDriver(driver) {
+async function loginAsDriver(driver, options = {}) {
+  const { skipPasswordCheck = false } = options;
+  const normalizedDriver = normalizeDriver(driver);
+
+  if (!skipPasswordCheck && normalizedDriver.hasPassword) {
+    state.pendingDriverLogin = normalizedDriver;
+    state.driverPasswordError = '';
+    openDriverPasswordModal(normalizedDriver);
+    return;
+  }
+
   state.currentUser = {
-    ...driver,
+    ...normalizedDriver,
     role: 'driver',
-    initials: computeInitials(driver.firstName, driver.lastName),
+    initials: computeInitials(normalizedDriver.firstName, normalizedDriver.lastName),
   };
   state.isAdmin = false;
-  elements.driverNameDisplay.textContent = `${driver.firstName} ${driver.lastName}`;
+  elements.driverNameDisplay.textContent = `${normalizedDriver.firstName} ${normalizedDriver.lastName}`;
   hideElement(elements.loginPage);
   showElement(elements.driverDashboard);
   hideElement(elements.adminDashboard);
+  closeDriverPasswordModal();
   switchTab('today');
   await loadDriverCourses();
+}
+
+function openDriverPasswordModal(driver) {
+  if (!elements.driverPasswordModal) {
+    const password = window.prompt('Mot de passe chauffeur');
+    if (password !== null) {
+      state.driverPasswordError = '';
+      state.pendingDriverLogin = driver;
+      handleDriverPasswordPrompt(password);
+    }
+    return;
+  }
+
+  if (elements.driverPasswordInput) {
+    elements.driverPasswordInput.value = '';
+  }
+  if (elements.driverPasswordError) {
+    elements.driverPasswordError.textContent = '';
+    elements.driverPasswordError.classList.add('hidden');
+  }
+  if (elements.driverPasswordName) {
+    elements.driverPasswordName.textContent = `${driver.firstName} ${driver.lastName}`;
+  }
+
+  showElement(elements.driverPasswordModal);
+
+  setTimeout(() => {
+    elements.driverPasswordInput?.focus();
+  }, 50);
+}
+
+function closeDriverPasswordModal() {
+  if (elements.driverPasswordModal) {
+    hideElement(elements.driverPasswordModal);
+  }
+  state.pendingDriverLogin = null;
+  state.driverPasswordError = '';
+  if (elements.driverPasswordError) {
+    elements.driverPasswordError.textContent = '';
+    elements.driverPasswordError.classList.add('hidden');
+  }
+  if (elements.driverPasswordInput) {
+    elements.driverPasswordInput.value = '';
+  }
+}
+
+async function processDriverPassword(password, { inline = false } = {}) {
+  if (!state.pendingDriverLogin) {
+    return;
+  }
+
+  const trimmed = typeof password === 'string' ? password.trim() : '';
+  if (!trimmed) {
+    if (inline && elements.driverPasswordError) {
+      elements.driverPasswordError.textContent = 'Veuillez renseigner le mot de passe chauffeur.';
+      elements.driverPasswordError.classList.remove('hidden');
+    } else {
+      alert('Veuillez renseigner le mot de passe chauffeur.');
+    }
+    return;
+  }
+
+  try {
+    const pending = state.pendingDriverLogin;
+    const result = await apiFetch('/drivers/login', {
+      method: 'POST',
+      body: JSON.stringify({ driverId: pending.id, password: trimmed }),
+    });
+
+    const normalized = normalizeDriver({
+      id: result.id || pending.id,
+      first_name: result.firstName || pending.firstName,
+      last_name: result.lastName || pending.lastName,
+      email: result.email ?? pending.email,
+      phone: result.phone ?? pending.phone,
+      has_password: result.hasPassword ?? pending.hasPassword,
+    });
+
+    closeDriverPasswordModal();
+    await loginAsDriver(normalized, { skipPasswordCheck: true });
+  } catch (error) {
+    state.driverPasswordError = error.message;
+    if (inline && elements.driverPasswordError) {
+      elements.driverPasswordError.textContent = error.message;
+      elements.driverPasswordError.classList.remove('hidden');
+    } else {
+      alert(error.message);
+    }
+  }
+}
+
+async function handleDriverPasswordSubmit(event) {
+  event.preventDefault();
+  await processDriverPassword(elements.driverPasswordInput?.value || '', { inline: true });
+}
+
+async function handleDriverPasswordPrompt(password) {
+  await processDriverPassword(password, { inline: false });
 }
 
 function setAdminSession(admin) {
@@ -348,19 +497,20 @@ function setAdminSession(admin) {
   state.currentUser = {
     ...normalized,
     role: 'admin',
+    adminLevel: normalized.role || 'standard',
+    token: admin.token || null,
   };
   state.isAdmin = true;
   state.adminFilters = { driverId: 'all', range: 'week' };
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
   state.settings = {
     emailRecipient: '',
-    gmailClientId: '',
-    gmailClientSecret: '',
-    gmailRefreshToken: '',
-    gmailRedirectUri: '',
     loaded: false,
     saving: false,
+    activeTab: 'email',
   };
+  state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
+  state.driverManagement.expanded = false;
   updateArchivePeriodInputs();
 
   hideElement(elements.loginPage);
@@ -369,25 +519,18 @@ function setAdminSession(admin) {
   closeAdminLoginModal();
 
   if (elements.adminIdentifierDisplay) {
-    elements.adminIdentifierDisplay.textContent = `${state.currentUser.initials} (${state.currentUser.identifier})`;
+    const levelLabel =
+      state.currentUser.adminLevel === 'superadmin'
+        ? 'Super admin'
+        : state.currentUser.adminLevel === 'manager'
+        ? 'Gestion'
+        : 'Standard';
+    elements.adminIdentifierDisplay.textContent = `${state.currentUser.initials} (${state.currentUser.identifier} • ${levelLabel})`;
   }
 
-  if (elements.emailRecipientInput) {
-    elements.emailRecipientInput.value = '';
-  }
-  if (elements.gmailClientIdInput) {
-    elements.gmailClientIdInput.value = '';
-  }
-  if (elements.gmailClientSecretInput) {
-    elements.gmailClientSecretInput.value = '';
-  }
-  if (elements.gmailRefreshTokenInput) {
-    elements.gmailRefreshTokenInput.value = '';
-  }
-  if (elements.gmailRedirectUriInput) {
-    elements.gmailRedirectUriInput.value = '';
-  }
   resetEmailSettingsStatus();
+  renderDriverManagementPanel();
+  renderSettingsTabs();
 
   state.adminView = 'planning';
   switchAdminView('planning');
@@ -398,6 +541,10 @@ function setAdminSession(admin) {
   loadAdminCourses();
   loadActivityLog();
   loadArchivedCourses();
+  loadEmailRecipient();
+  if (state.currentUser.adminLevel === 'superadmin') {
+    loadAdmins();
+  }
 }
 
 function openAdminLoginModal() {
@@ -408,11 +555,6 @@ function openAdminLoginModal() {
   if (elements.adminPasswordInput) {
     elements.adminPasswordInput.value = '';
   }
-  elements.adminCreateForm?.reset();
-  if (elements.adminCreatePassword) {
-    elements.adminCreatePassword.value = '';
-  }
-  updateAdminIdentifierPreview();
   loadAdmins();
   showElement(elements.adminLoginModal);
 }
@@ -450,43 +592,12 @@ async function handleAdminLogin(event) {
   }
 }
 
-async function handleAdminCreate(event) {
-  event.preventDefault();
-
-  const firstName = elements.adminCreateFirstName.value.trim();
-  const lastName = elements.adminCreateLastName.value.trim();
-  const password = elements.adminCreatePassword?.value || '';
-
-  if (!firstName || !lastName) {
-    alert('Veuillez renseigner un prénom et un nom.');
-    return;
-  }
-
-  if (!password) {
-    alert('Veuillez définir un mot de passe pour ce compte administrateur.');
-    return;
-  }
-
-  try {
-    const admin = await apiFetch('/admins', {
-      method: 'POST',
-      body: JSON.stringify({ firstName, lastName, password }),
-    });
-
-    await loadAdmins();
-    alert(`Compte administrateur créé. Identifiant : ${admin.identifier}`);
-    setAdminSession(admin);
-  } catch (error) {
-    console.error('Erreur lors de la création du compte administrateur', error);
-    alert(error.message);
-  }
-}
-
 async function loadAdmins() {
   try {
     const admins = await apiFetch('/admins');
     state.admins = admins.map(normalizeAdmin);
     renderAdminAccounts();
+    renderAdminManagement();
   } catch (error) {
     console.error('Erreur lors du chargement des comptes administrateurs', error);
   }
@@ -517,7 +628,10 @@ function renderAdminAccounts() {
     item.innerHTML = `
       <div>
         <div class="font-medium text-gray-800">${admin.firstName} ${admin.lastName}</div>
-        <div class="text-xs text-gray-500">Identifiant : <span class="font-mono">${admin.identifier}</span></div>
+        <div class="text-xs text-gray-500 flex flex-wrap gap-2 items-center">
+          <span>Identifiant : <span class="font-mono">${admin.identifier}</span></span>
+          <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">${formatAdminLevel(admin.role)}</span>
+        </div>
       </div>
       <button type="button" class="text-blue-600 hover:text-blue-800 text-xs font-medium">Utiliser</button>
     `;
@@ -534,25 +648,93 @@ function renderAdminAccounts() {
   elements.adminAccountsList.appendChild(list);
 }
 
-function updateAdminIdentifierPreview() {
-  if (!elements.adminIdentifierPreview) {
+function renderAdminManagement() {
+  if (!elements.adminManagementSection) {
     return;
   }
 
-  const firstName = elements.adminCreateFirstName.value;
-  const lastName = elements.adminCreateLastName.value;
-  const identifier = computeAdminIdentifier(firstName, lastName);
-
-  if (identifier) {
-    elements.adminIdentifierPreviewValue.textContent = identifier;
-    showElement(elements.adminIdentifierPreview);
-  } else {
-    elements.adminIdentifierPreviewValue.textContent = '';
-    hideElement(elements.adminIdentifierPreview);
+  if (state.currentUser?.adminLevel !== 'superadmin') {
+    hideElement(elements.adminManagementSection);
+    return;
   }
+
+  showElement(elements.adminManagementSection);
+
+  if (elements.adminManagementStatus) {
+    elements.adminManagementStatus.textContent = '';
+    elements.adminManagementStatus.classList.add('hidden');
+  }
+
+  const listContainer = elements.adminManagementList;
+  if (!listContainer) {
+    return;
+  }
+
+  listContainer.innerHTML = '';
+
+  if (!state.admins.length) {
+    const empty = document.createElement('p');
+    empty.className = 'text-sm text-gray-500';
+    empty.textContent = 'Aucun administrateur enregistré.';
+    listContainer.appendChild(empty);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'space-y-3';
+
+  state.admins.forEach((admin) => {
+    const item = document.createElement('li');
+    item.className =
+      'border border-gray-200 rounded-md px-4 py-3 bg-white shadow-sm flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3';
+
+    const info = document.createElement('div');
+    info.innerHTML = `
+      <div class="font-medium text-gray-800">${admin.firstName} ${admin.lastName}</div>
+      <div class="text-xs text-gray-500 flex flex-wrap gap-2 items-center mt-1">
+        <span>Identifiant : <span class="font-mono">${admin.identifier}</span></span>
+        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">${formatAdminLevel(admin.role)}</span>
+      </div>
+    `;
+
+    const actions = document.createElement('div');
+    actions.className = 'flex items-center gap-2';
+
+    if (admin.identifier.toLowerCase() === 'lsaquet') {
+      const badge = document.createElement('span');
+      badge.className = 'text-xs text-green-600 font-semibold';
+      badge.textContent = 'Compte principal';
+      actions.appendChild(badge);
+    } else {
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'btn-danger text-xs';
+      deleteBtn.textContent = 'Supprimer';
+      deleteBtn.addEventListener('click', () => handleAdminDeletion(admin.id));
+      actions.appendChild(deleteBtn);
+    }
+
+    item.appendChild(info);
+    item.appendChild(actions);
+    list.appendChild(item);
+  });
+
+  listContainer.appendChild(list);
 }
 
-function logout() {
+async function logout(event) {
+  if (event?.preventDefault) {
+    event.preventDefault();
+  }
+
+  if (state.currentUser?.role === 'admin' && state.currentUser?.token) {
+    try {
+      await apiFetch('/admins/logout', { method: 'POST' });
+    } catch (error) {
+      console.warn('Erreur lors de la fermeture de session administrateur', error);
+    }
+  }
+
   state.currentUser = null;
   state.isAdmin = false;
   state.driverCourses = [];
@@ -562,13 +744,12 @@ function logout() {
   state.archiveFilters = { driverId: 'all', merchandise: 'all', period: 'week', from: null, to: null };
   state.settings = {
     emailRecipient: '',
-    gmailClientId: '',
-    gmailClientSecret: '',
-    gmailRefreshToken: '',
-    gmailRedirectUri: '',
     loaded: false,
     saving: false,
+    activeTab: 'email',
   };
+  state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
+  state.driverManagement.expanded = false;
   state.activityLog = [];
   state.courseCache.clear();
   elements.lastnameInput.value = '';
@@ -578,6 +759,7 @@ function logout() {
   hideElement(elements.courseModal);
   closePhotoModal();
   closeCourseEditor();
+  closeDriverPasswordModal();
   closeAdminLoginModal();
   if (elements.adminIdentifierDisplay) {
     elements.adminIdentifierDisplay.textContent = '';
@@ -600,19 +782,16 @@ function logout() {
   if (elements.emailRecipientInput) {
     elements.emailRecipientInput.value = '';
   }
-  if (elements.gmailClientIdInput) {
-    elements.gmailClientIdInput.value = '';
-  }
-  if (elements.gmailClientSecretInput) {
-    elements.gmailClientSecretInput.value = '';
-  }
-  if (elements.gmailRefreshTokenInput) {
-    elements.gmailRefreshTokenInput.value = '';
-  }
-  if (elements.gmailRedirectUriInput) {
-    elements.gmailRedirectUriInput.value = '';
-  }
   resetEmailSettingsStatus();
+  if (elements.adminPasswordForm) {
+    elements.adminPasswordForm.reset();
+  }
+  if (elements.adminPasswordFeedback) {
+    elements.adminPasswordFeedback.textContent = '';
+    elements.adminPasswordFeedback.classList.add('hidden');
+  }
+  renderDriverManagementPanel();
+  renderSettingsTabs();
   state.adminView = 'planning';
   updateAdminRangeButtons();
   updateArchivePeriodInputs();
@@ -685,7 +864,23 @@ function switchAdminView(view) {
   }
 
   if (view === 'settings') {
-    loadEmailSettings();
+    ensureSettingsData();
+  }
+}
+
+function renderDriverManagementPanel() {
+  if (!elements.driverManagementPanel || !elements.driverManagementToggle) {
+    return;
+  }
+
+  if (state.driverManagement.expanded) {
+    showElement(elements.driverManagementPanel);
+    elements.driverManagementToggle.textContent = 'Masquer la gestion des chauffeurs';
+    elements.driverManagementToggle.setAttribute('aria-expanded', 'true');
+  } else {
+    hideElement(elements.driverManagementPanel);
+    elements.driverManagementToggle.textContent = 'Afficher la gestion des chauffeurs';
+    elements.driverManagementToggle.setAttribute('aria-expanded', 'false');
   }
 }
 
@@ -701,6 +896,69 @@ function updateAdminRangeButtons() {
       button.classList.remove('filter-chip--active');
     }
   });
+}
+
+function renderSettingsTabs() {
+  if (elements.settingsTabButtons) {
+    elements.settingsTabButtons.forEach((button) => {
+      const tabKey = button.getAttribute('data-settings-tab');
+      const isAdminTab = tabKey === 'admins';
+      if (isAdminTab && state.currentUser?.adminLevel !== 'superadmin') {
+        button.classList.add('hidden');
+      } else {
+        button.classList.remove('hidden');
+      }
+
+      if (tabKey === state.settings.activeTab) {
+        button.classList.add('settings-tab--active');
+      } else {
+        button.classList.remove('settings-tab--active');
+      }
+    });
+  }
+
+  if (elements.settingsPanels) {
+    elements.settingsPanels.forEach((panel) => {
+      const panelKey = panel.getAttribute('data-settings-panel');
+      const isAdminPanel = panelKey === 'admins';
+      if (isAdminPanel && state.currentUser?.adminLevel !== 'superadmin') {
+        hideElement(panel);
+        return;
+      }
+      if (panelKey === state.settings.activeTab) {
+        showElement(panel);
+      } else {
+        hideElement(panel);
+      }
+    });
+  }
+}
+
+function ensureSettingsData(tab = state.settings.activeTab) {
+  if (!state.isAdmin) {
+    return;
+  }
+
+  if (tab === 'email') {
+    loadEmailRecipient();
+  } else if (tab === 'drivers') {
+    loadDriverCredentials();
+  } else if (tab === 'admins' && state.currentUser?.adminLevel === 'superadmin') {
+    renderAdminManagement();
+  }
+}
+
+function setSettingsTab(tab) {
+  if (tab === 'admins' && state.currentUser?.adminLevel !== 'superadmin') {
+    return;
+  }
+
+  if (state.settings.activeTab !== tab) {
+    state.settings.activeTab = tab;
+    renderSettingsTabs();
+  }
+
+  ensureSettingsData(tab);
 }
 
 async function loadDriverCourses() {
@@ -1124,52 +1382,22 @@ function showEmailSettingsStatus(message, isError = false) {
   elements.emailSettingsStatus.classList.add(isError ? 'text-red-600' : 'text-green-600');
 }
 
-async function loadEmailSettings(force = false) {
+async function loadEmailRecipient(force = false) {
   if (!elements.emailSettingsForm) {
     return;
   }
 
   if (state.settings.loaded && !force) {
     elements.emailRecipientInput.value = state.settings.emailRecipient;
-    if (elements.gmailClientIdInput) {
-      elements.gmailClientIdInput.value = state.settings.gmailClientId;
-    }
-    if (elements.gmailClientSecretInput) {
-      elements.gmailClientSecretInput.value = state.settings.gmailClientSecret;
-    }
-    if (elements.gmailRefreshTokenInput) {
-      elements.gmailRefreshTokenInput.value = state.settings.gmailRefreshToken;
-    }
-    if (elements.gmailRedirectUriInput) {
-      elements.gmailRedirectUriInput.value =
-        state.settings.gmailRedirectUri || DEFAULT_GMAIL_REDIRECT_URI;
-    }
     return;
   }
 
   try {
     resetEmailSettingsStatus();
-    const response = await apiFetch('/settings/email-config');
-    state.settings.emailRecipient = response.recipient || '';
-    state.settings.gmailClientId = response.gmailClientId || '';
-    state.settings.gmailClientSecret = response.gmailClientSecret || '';
-    state.settings.gmailRefreshToken = response.gmailRefreshToken || '';
-    state.settings.gmailRedirectUri = response.gmailRedirectUri || '';
+    const response = await apiFetch('/settings/email-recipient');
+    state.settings.emailRecipient = response.email || '';
     state.settings.loaded = true;
     elements.emailRecipientInput.value = state.settings.emailRecipient;
-    if (elements.gmailClientIdInput) {
-      elements.gmailClientIdInput.value = state.settings.gmailClientId;
-    }
-    if (elements.gmailClientSecretInput) {
-      elements.gmailClientSecretInput.value = state.settings.gmailClientSecret;
-    }
-    if (elements.gmailRefreshTokenInput) {
-      elements.gmailRefreshTokenInput.value = state.settings.gmailRefreshToken;
-    }
-    if (elements.gmailRedirectUriInput) {
-      elements.gmailRedirectUriInput.value =
-        state.settings.gmailRedirectUri || DEFAULT_GMAIL_REDIRECT_URI;
-    }
   } catch (error) {
     console.error('Erreur lors du chargement de la configuration email', error);
     showEmailSettingsStatus(error.message || "Impossible de charger l'adresse email.", true);
@@ -1188,24 +1416,9 @@ async function handleEmailSettingsSubmit(event) {
   }
 
   const email = elements.emailRecipientInput?.value.trim() || '';
-  const gmailClientId = elements.gmailClientIdInput?.value.trim() || '';
-  const gmailClientSecret = elements.gmailClientSecretInput?.value.trim() || '';
-  const gmailRefreshToken = elements.gmailRefreshTokenInput?.value.trim() || '';
-  const gmailRedirectUri =
-    elements.gmailRedirectUriInput?.value.trim() || DEFAULT_GMAIL_REDIRECT_URI;
 
   if (!email) {
     showEmailSettingsStatus('Veuillez renseigner une adresse email.', true);
-    return;
-  }
-
-  if (!gmailClientId || !gmailClientSecret || !gmailRefreshToken) {
-    showEmailSettingsStatus('Veuillez renseigner les identifiants Gmail requis.', true);
-    return;
-  }
-
-  if (!gmailRedirectUri) {
-    showEmailSettingsStatus('Veuillez renseigner une Redirect URI Gmail.', true);
     return;
   }
 
@@ -1219,49 +1432,284 @@ async function handleEmailSettingsSubmit(event) {
       submitButton.classList.add('opacity-50', 'cursor-not-allowed');
     }
 
-    const response = await apiFetch('/settings/email-config', {
+    const response = await apiFetch('/settings/email-recipient', {
       method: 'PUT',
-      body: JSON.stringify({
-        recipient: email,
-        gmailClientId,
-        gmailClientSecret,
-        gmailRefreshToken,
-        gmailRedirectUri,
-      }),
+      body: JSON.stringify({ email }),
     });
 
-    state.settings.emailRecipient = response.recipient || email;
-    state.settings.gmailClientId = response.gmailClientId || gmailClientId;
-    state.settings.gmailClientSecret = response.gmailClientSecret || gmailClientSecret;
-    state.settings.gmailRefreshToken = response.gmailRefreshToken || gmailRefreshToken;
-    state.settings.gmailRedirectUri = response.gmailRedirectUri || gmailRedirectUri;
+    state.settings.emailRecipient = response.email || email;
     state.settings.loaded = true;
 
     elements.emailRecipientInput.value = state.settings.emailRecipient;
-    if (elements.gmailClientIdInput) {
-      elements.gmailClientIdInput.value = state.settings.gmailClientId;
-    }
-    if (elements.gmailClientSecretInput) {
-      elements.gmailClientSecretInput.value = state.settings.gmailClientSecret;
-    }
-    if (elements.gmailRefreshTokenInput) {
-      elements.gmailRefreshTokenInput.value = state.settings.gmailRefreshToken;
-    }
-    if (elements.gmailRedirectUriInput) {
-      elements.gmailRedirectUriInput.value =
-        state.settings.gmailRedirectUri || DEFAULT_GMAIL_REDIRECT_URI;
-    }
 
-    showEmailSettingsStatus('Configuration email mise à jour avec succès.');
+    showEmailSettingsStatus('Adresse email mise à jour avec succès.');
   } catch (error) {
-    console.error("Erreur lors de l'enregistrement de la configuration email", error);
-    showEmailSettingsStatus(error.message || 'Impossible de mettre à jour la configuration email.', true);
+    console.error("Erreur lors de l'enregistrement de l'adresse email", error);
+    showEmailSettingsStatus(error.message || "Impossible de mettre à jour l'adresse email.", true);
   } finally {
     state.settings.saving = false;
     if (submitButton) {
       submitButton.disabled = false;
       submitButton.classList.remove('opacity-50', 'cursor-not-allowed');
     }
+  }
+}
+
+async function loadDriverCredentials() {
+  if (!elements.driverPasswordList || state.driverPasswordManagement.loading) {
+    return;
+  }
+
+  try {
+    state.driverPasswordManagement.loading = true;
+    const drivers = await apiFetch('/drivers/credentials');
+    state.driverPasswordManagement.drivers = drivers.map(normalizeDriver);
+    renderDriverCredentials();
+  } catch (error) {
+    console.error('Erreur lors du chargement des mots de passe chauffeurs', error);
+    if (elements.driverPasswordList) {
+      elements.driverPasswordList.innerHTML = `<p class="text-sm text-red-600">${
+        error.message || 'Impossible de récupérer les chauffeurs.'
+      }</p>`;
+    }
+  } finally {
+    state.driverPasswordManagement.loading = false;
+  }
+}
+
+function renderDriverCredentials() {
+  if (!elements.driverPasswordList) {
+    return;
+  }
+
+  const drivers = state.driverPasswordManagement.drivers || [];
+  elements.driverPasswordList.innerHTML = '';
+
+  if (!drivers.length) {
+    if (elements.driverPasswordEmpty) {
+      elements.driverPasswordEmpty.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (elements.driverPasswordEmpty) {
+    elements.driverPasswordEmpty.classList.add('hidden');
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'space-y-3';
+
+  drivers.forEach((driver) => {
+    const item = document.createElement('li');
+    item.className =
+      'border border-gray-200 rounded-md px-4 py-3 bg-white shadow-sm flex flex-col gap-3';
+
+    const statusBadge = driver.hasPassword
+      ? '<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs"><i class="fas fa-lock"></i> Protégé</span>'
+      : '<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 text-xs"><i class="fas fa-unlock"></i> Aucun mot de passe</span>';
+
+    item.innerHTML = `
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div>
+          <div class="font-medium text-gray-800">${driver.firstName} ${driver.lastName}</div>
+          <div class="text-xs text-gray-500 mt-1 flex items-center gap-2">${statusBadge}</div>
+        </div>
+      </div>
+    `;
+
+    const actionsContainer = document.createElement('div');
+    actionsContainer.className = 'flex flex-col sm:flex-row sm:items-center gap-2';
+
+    if (state.driverPasswordManagement.editingDriverId === driver.id) {
+      const form = document.createElement('form');
+      form.className = 'flex flex-col sm:flex-row gap-2 w-full';
+      form.innerHTML = `
+        <input type="password" class="form-input sm:flex-1" placeholder="Nouveau mot de passe" required />
+        <div class="flex gap-2">
+          <button type="submit" class="btn-primary text-sm">Enregistrer</button>
+          <button type="button" data-action="cancel" class="btn-secondary text-sm">Annuler</button>
+        </div>
+      `;
+      form.addEventListener('submit', (event) => handleDriverPasswordSave(event, driver.id));
+      const cancelButton = form.querySelector('[data-action="cancel"]');
+      cancelButton.addEventListener('click', () => {
+        state.driverPasswordManagement.editingDriverId = null;
+        renderDriverCredentials();
+      });
+      actionsContainer.appendChild(form);
+      setTimeout(() => {
+        form.querySelector('input')?.focus();
+      }, 0);
+    } else {
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'btn-secondary text-xs sm:text-sm';
+      editBtn.textContent = driver.hasPassword ? 'Modifier le mot de passe' : 'Définir un mot de passe';
+      editBtn.addEventListener('click', () => {
+        state.driverPasswordManagement.editingDriverId = driver.id;
+        renderDriverCredentials();
+      });
+      actionsContainer.appendChild(editBtn);
+
+      if (driver.hasPassword) {
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn-danger text-xs sm:text-sm';
+        removeBtn.textContent = 'Supprimer le mot de passe';
+        removeBtn.addEventListener('click', () => removeDriverPassword(driver.id));
+        actionsContainer.appendChild(removeBtn);
+      }
+    }
+
+    item.appendChild(actionsContainer);
+    list.appendChild(item);
+  });
+
+  elements.driverPasswordList.appendChild(list);
+}
+
+async function handleDriverPasswordSave(event, driverId) {
+  event.preventDefault();
+  const input = event.target.querySelector('input[type="password"]');
+  const newPassword = input?.value || '';
+
+  if (!newPassword.trim()) {
+    alert('Veuillez renseigner un mot de passe.');
+    return;
+  }
+
+  try {
+    await apiFetch(`/drivers/${driverId}/password`, {
+      method: 'PUT',
+      body: JSON.stringify({ newPassword }),
+    });
+    state.driverPasswordManagement.editingDriverId = null;
+    await loadDriverCredentials();
+  } catch (error) {
+    console.error('Erreur lors de la mise à jour du mot de passe chauffeur', error);
+    alert(error.message);
+  }
+}
+
+async function removeDriverPassword(driverId) {
+  if (!confirm('Supprimer le mot de passe de ce chauffeur ?')) {
+    return;
+  }
+
+  try {
+    await apiFetch(`/drivers/${driverId}/password`, { method: 'DELETE' });
+    state.driverPasswordManagement.editingDriverId = null;
+    await loadDriverCredentials();
+  } catch (error) {
+    console.error('Erreur lors de la suppression du mot de passe chauffeur', error);
+    alert(error.message);
+  }
+}
+
+function setAdminManagementStatus(message, isError = false) {
+  if (!elements.adminManagementStatus) {
+    if (isError) {
+      alert(message);
+    } else {
+      console.info(message);
+    }
+    return;
+  }
+
+  elements.adminManagementStatus.textContent = message;
+  elements.adminManagementStatus.classList.remove('hidden');
+  elements.adminManagementStatus.classList.remove('text-green-600', 'text-red-600');
+  elements.adminManagementStatus.classList.add(isError ? 'text-red-600' : 'text-green-600');
+}
+
+async function handleAdminCreation(event) {
+  event.preventDefault();
+
+  if (!elements.adminManagementCreateForm) {
+    return;
+  }
+
+  const firstName = elements.adminManagementFirstName?.value.trim() || '';
+  const lastName = elements.adminManagementLastName?.value.trim() || '';
+  const password = elements.adminManagementPassword?.value || '';
+  const role = elements.adminManagementRole?.value || 'standard';
+
+  if (!firstName || !lastName || !password) {
+    setAdminManagementStatus('Veuillez renseigner prénom, nom et mot de passe.', true);
+    return;
+  }
+
+  try {
+    setAdminManagementStatus('Création du compte administrateur en cours...');
+    await apiFetch('/admins', {
+      method: 'POST',
+      body: JSON.stringify({ firstName, lastName, password, role }),
+    });
+    setAdminManagementStatus('Administrateur créé avec succès. Identifiant visible dans la liste.');
+    elements.adminManagementCreateForm.reset();
+    await loadAdmins();
+  } catch (error) {
+    console.error('Erreur lors de la création du compte administrateur', error);
+    setAdminManagementStatus(error.message || 'Impossible de créer ce compte administrateur.', true);
+  }
+}
+
+async function handleAdminDeletion(adminId) {
+  if (!confirm('Supprimer cet administrateur ?')) {
+    return;
+  }
+
+  try {
+    await apiFetch(`/admins/${adminId}`, { method: 'DELETE' });
+    setAdminManagementStatus('Administrateur supprimé.');
+    await loadAdmins();
+  } catch (error) {
+    console.error('Erreur lors de la suppression du compte administrateur', error);
+    setAdminManagementStatus(error.message || 'Impossible de supprimer cet administrateur.', true);
+  }
+}
+
+function setAdminPasswordFeedback(message, isError = false) {
+  if (!elements.adminPasswordFeedback) {
+    if (isError) {
+      alert(message);
+    } else {
+      console.info(message);
+    }
+    return;
+  }
+
+  elements.adminPasswordFeedback.textContent = message;
+  elements.adminPasswordFeedback.classList.remove('hidden');
+  elements.adminPasswordFeedback.classList.remove('text-green-600', 'text-red-600');
+  elements.adminPasswordFeedback.classList.add(isError ? 'text-red-600' : 'text-green-600');
+}
+
+async function handleAdminPasswordChange(event) {
+  event.preventDefault();
+
+  if (!state.currentUser?.id) {
+    return;
+  }
+
+  const currentPassword = elements.adminPasswordCurrent?.value || '';
+  const newPassword = elements.adminPasswordNew?.value || '';
+
+  if (!newPassword.trim()) {
+    setAdminPasswordFeedback('Veuillez renseigner un nouveau mot de passe.', true);
+    return;
+  }
+
+  try {
+    await apiFetch(`/admins/${state.currentUser.id}/password`, {
+      method: 'PUT',
+      body: JSON.stringify({ currentPassword, newPassword }),
+    });
+    setAdminPasswordFeedback('Mot de passe mis à jour avec succès.');
+    elements.adminPasswordForm?.reset();
+  } catch (error) {
+    console.error('Erreur lors du changement de mot de passe administrateur', error);
+    setAdminPasswordFeedback(error.message || 'Impossible de mettre à jour le mot de passe.', true);
   }
 }
 
@@ -1824,6 +2272,13 @@ async function openCourseModal(courseId) {
       editButton.innerHTML = '<i class="fas fa-edit mr-1"></i> Modifier';
       editButton.addEventListener('click', () => editCourse(course.id));
       elements.modalActions.appendChild(editButton);
+
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition';
+      deleteButton.innerHTML = '<i class="fas fa-trash mr-1"></i> Supprimer';
+      deleteButton.addEventListener('click', () => deleteCourse(course.id));
+      elements.modalActions.appendChild(deleteButton);
     } else if (course.status !== 'completed' && !isArchived) {
       const validateButton = document.createElement('button');
       validateButton.type = 'button';
@@ -2009,10 +2464,11 @@ function registerEventListeners() {
 
   elements.closeAdminLoginModalBtn?.addEventListener('click', closeAdminLoginModal);
   elements.adminLoginForm?.addEventListener('submit', handleAdminLogin);
-  elements.adminCreateForm?.addEventListener('submit', handleAdminCreate);
   elements.driverManagementForm?.addEventListener('submit', handleAddDriver);
-  elements.adminCreateFirstName?.addEventListener('input', updateAdminIdentifierPreview);
-  elements.adminCreateLastName?.addEventListener('input', updateAdminIdentifierPreview);
+  elements.driverManagementToggle?.addEventListener('click', () => {
+    state.driverManagement.expanded = !state.driverManagement.expanded;
+    renderDriverManagementPanel();
+  });
 
   elements.archivePeriodFilter?.addEventListener('change', handleArchivePeriodChange);
   elements.archiveDriverFilter?.addEventListener('change', handleArchiveFiltersChange);
@@ -2020,6 +2476,20 @@ function registerEventListeners() {
   elements.archiveFromInput?.addEventListener('change', handleArchiveDatesChange);
   elements.archiveToInput?.addEventListener('change', handleArchiveDatesChange);
   elements.emailSettingsForm?.addEventListener('submit', handleEmailSettingsSubmit);
+  elements.driverPasswordForm?.addEventListener('submit', handleDriverPasswordSubmit);
+  elements.driverPasswordCancel?.addEventListener('click', () => {
+    closeDriverPasswordModal();
+  });
+  if (elements.settingsTabButtons) {
+    elements.settingsTabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const tabKey = button.getAttribute('data-settings-tab');
+        setSettingsTab(tabKey || 'email');
+      });
+    });
+  }
+  elements.adminManagementCreateForm?.addEventListener('submit', handleAdminCreation);
+  elements.adminPasswordForm?.addEventListener('submit', handleAdminPasswordChange);
 
   window.addEventListener('click', (event) => {
     if (event.target === elements.courseModal) {
@@ -2034,6 +2504,9 @@ function registerEventListeners() {
     if (event.target === elements.adminLoginModal) {
       closeAdminLoginModal();
     }
+    if (event.target === elements.driverPasswordModal) {
+      closeDriverPasswordModal();
+    }
   });
 }
 
@@ -2041,6 +2514,8 @@ function init() {
   setDefaultCourseDateTime();
   updateAdminRangeButtons();
   updateArchivePeriodInputs();
+  renderDriverManagementPanel();
+  renderSettingsTabs();
   registerEventListeners();
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -54,6 +54,7 @@ const state = {
     saving: false,
     activeTab: 'email',
   },
+  adminManagementView: 'list',
   adminEdit: { ...ADMIN_EDIT_DEFAULT },
 };
 
@@ -170,6 +171,8 @@ const elements = {
   adminManagementPassword: document.getElementById('admin-management-password'),
   adminManagementRole: document.getElementById('admin-management-role'),
   adminManagementStatus: document.getElementById('admin-management-status'),
+  adminManagementTabButtons: document.querySelectorAll('[data-admin-management-tab]'),
+  adminManagementPanels: document.querySelectorAll('[data-admin-management-panel]'),
   adminPasswordForm: document.getElementById('admin-password-form'),
   adminPasswordCurrent: document.getElementById('admin-password-current'),
   adminPasswordNew: document.getElementById('admin-password-new'),
@@ -533,6 +536,7 @@ function setAdminSession(admin, options = {}) {
     saving: false,
     activeTab: settingsTab,
   };
+  state.adminManagementView = options.adminManagementView || 'list';
   state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
   state.driverManagement.expanded = false;
   state.driverManagement.loading = false;
@@ -767,6 +771,46 @@ async function handleAdminUpdate(event, adminId) {
   }
 }
 
+function renderAdminManagementTabs() {
+  const buttons = elements.adminManagementTabButtons;
+  if (buttons && buttons.length) {
+    buttons.forEach((button) => {
+      const tabKey = button.getAttribute('data-admin-management-tab') || 'list';
+      const isActive = tabKey === state.adminManagementView;
+      if (isActive) {
+        button.classList.add('admin-management-tab--active');
+      } else {
+        button.classList.remove('admin-management-tab--active');
+      }
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    });
+  }
+
+  const panels = elements.adminManagementPanels;
+  if (panels && panels.length) {
+    panels.forEach((panel) => {
+      const panelKey = panel.getAttribute('data-admin-management-panel') || '';
+      if (panelKey === state.adminManagementView) {
+        showElement(panel);
+      } else {
+        hideElement(panel);
+      }
+    });
+  }
+}
+
+function setAdminManagementView(view) {
+  const normalizedView = view === 'create' ? 'create' : 'list';
+  if (state.adminManagementView !== normalizedView) {
+    state.adminManagementView = normalizedView;
+    if (state.currentUser?.role === 'admin') {
+      persistSessionState();
+    }
+  }
+
+  renderAdminManagementTabs();
+}
+
 function renderAdminManagement() {
   if (!elements.adminManagementSection) {
     return;
@@ -778,6 +822,7 @@ function renderAdminManagement() {
   }
 
   showElement(elements.adminManagementSection);
+  renderAdminManagementTabs();
 
   if (elements.adminManagementStatus) {
     elements.adminManagementStatus.textContent = '';
@@ -1017,6 +1062,7 @@ async function logout(event) {
     saving: false,
     activeTab: 'email',
   };
+  state.adminManagementView = 'list';
   state.driverPasswordManagement = { drivers: [], loading: false, editingDriverId: null };
   state.driverManagement.expanded = false;
   state.driverManagement.loading = false;
@@ -1213,6 +1259,10 @@ function renderSettingsTabs() {
         hideElement(panel);
       }
     });
+  }
+
+  if (state.currentUser?.adminLevel === 'superadmin') {
+    renderAdminManagementTabs();
   }
 }
 
@@ -2780,6 +2830,7 @@ function persistSessionState() {
     session.token = state.currentUser.token || null;
     session.adminView = state.adminView;
     session.settingsTab = state.settings?.activeTab || 'email';
+    session.adminManagementView = state.adminManagementView || 'list';
     session.adminFilters = { ...state.adminFilters };
     session.archiveFilters = { ...state.archiveFilters };
   }
@@ -2921,6 +2972,7 @@ async function restoreSessionFromStorage() {
         view: saved.adminView || 'planning',
         driverTab: saved.activeDriverTab || 'week',
         settingsTab: saved.settingsTab || 'email',
+        adminManagementView: saved.adminManagementView || 'list',
         adminFilters: saved.adminFilters || {},
         archiveFilters: saved.archiveFilters || {},
       });
@@ -3042,6 +3094,14 @@ function registerEventListeners() {
       button.addEventListener('click', () => {
         const tabKey = button.getAttribute('data-settings-tab');
         setSettingsTab(tabKey || 'email');
+      });
+    });
+  }
+  if (elements.adminManagementTabButtons && elements.adminManagementTabButtons.length) {
+    elements.adminManagementTabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const tabKey = button.getAttribute('data-admin-management-tab') || 'list';
+        setAdminManagementView(tabKey);
       });
     });
   }

--- a/index.html
+++ b/index.html
@@ -143,6 +143,41 @@
       </div>
     </div>
 
+    <div id="course-issue-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal__dialog max-w-md">
+        <div class="p-6 space-y-4">
+          <div class="flex items-start justify-between">
+            <div>
+              <h3 class="text-xl font-semibold text-gray-800">Signaler un problème</h3>
+              <p class="text-sm text-gray-500">Décrivez brièvement le problème rencontré sur cette course.</p>
+            </div>
+            <button id="course-issue-cancel" class="text-gray-400 hover:text-gray-600" aria-label="Fermer">
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
+          <form id="course-issue-form" class="space-y-4">
+            <div>
+              <label for="course-issue-comment" class="form-label">Commentaire</label>
+              <textarea
+                id="course-issue-comment"
+                class="form-input"
+                rows="4"
+                placeholder="Expliquez le problème rencontré..."
+                required
+              ></textarea>
+            </div>
+            <p id="course-issue-error" class="text-sm text-red-600 hidden"></p>
+            <div class="flex justify-end gap-3">
+              <button type="button" id="course-issue-close" class="btn-secondary px-4 py-2">Annuler</button>
+              <button type="submit" class="btn-danger px-4 py-2">
+                <i class="fas fa-paper-plane mr-2"></i>Envoyer
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
     <div id="driver-dashboard" class="min-h-screen hidden">
       <header class="bg-green-600 text-white shadow-md">
         <div class="container mx-auto px-4 py-3 flex justify-between items-center">
@@ -692,6 +727,51 @@
               <button type="submit" class="btn-primary">Enregistrer</button>
             </div>
           </form>
+        </div>
+      </div>
+    </div>
+
+    <div id="messaging-fab" class="messaging-fab hidden">
+      <button id="messaging-toggle" class="messaging-fab__button" aria-label="Ouvrir la messagerie">
+        <i class="fas fa-comments"></i>
+        <span id="messaging-unread" class="messaging-fab__badge hidden">0</span>
+      </button>
+    </div>
+
+    <div id="messaging-panel" class="messaging-panel hidden" aria-hidden="true">
+      <div class="messaging-panel__container">
+        <div class="messaging-panel__header">
+          <div>
+            <h3 class="messaging-panel__title">Messagerie sécurisée</h3>
+            <p id="messaging-subtitle" class="messaging-panel__subtitle">Contactez l'administration en direct.</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <select id="messaging-driver-picker" class="messaging-panel__select hidden"></select>
+            <button id="messaging-close" class="messaging-panel__close" aria-label="Fermer la messagerie">
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
+        </div>
+        <div class="messaging-panel__body">
+          <aside id="messaging-thread-list" class="messaging-thread-list hidden" aria-label="Conversations"></aside>
+          <div class="messaging-conversation">
+            <div id="messaging-messages" class="messaging-messages" aria-live="polite"></div>
+            <form id="messaging-form" class="messaging-form">
+              <textarea
+                id="messaging-input"
+                class="messaging-input"
+                rows="2"
+                placeholder="Écrivez votre message..."
+                required
+              ></textarea>
+              <div class="messaging-actions">
+                <span id="messaging-error" class="messaging-error hidden"></span>
+                <button type="submit" class="messaging-send">
+                  <i class="fas fa-paper-plane mr-2"></i>Envoyer
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                 Connectez-vous avec votre identifiant administrateur. Pour toute création de compte, contactez Laurent Saquet.
               </p>
             </div>
-            <button id="close-admin-login" class="text-gray-400 hover:text-gray-600">
+            <button id="close-admin-login" class="text-gray-400 hover:text-gray-600 text-2xl" title="Fermer l'accès administration">
               <i class="fas fa-times"></i>
               <span class="sr-only">Fermer la fenêtre d'authentification</span>
             </button>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             <div>
               <h3 class="text-xl font-semibold text-gray-800">Accès administration</h3>
               <p class="text-sm text-gray-500">
-                Connectez-vous avec votre identifiant ou créez un nouveau compte administrateur.
+                Connectez-vous avec votre identifiant administrateur. Pour toute création de compte, contactez Laurent Saquet.
               </p>
             </div>
             <button id="close-admin-login" class="text-gray-400 hover:text-gray-600">
@@ -117,46 +117,38 @@
               </div>
             </section>
 
-            <section class="space-y-4 border-t border-gray-200 pt-6">
-              <div>
-                <h4 class="text-lg font-semibold text-gray-800">Créer un compte administrateur</h4>
-                <p class="text-sm text-gray-500">
-                  Renseignez le prénom et le nom. L'identifiant généré reprendra l'initiale du prénom suivie du nom.
-                </p>
-              </div>
-              <form id="admin-create-form" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label for="admin-create-first-name" class="form-label">Prénom</label>
-                  <input type="text" id="admin-create-first-name" class="form-input" required />
-                </div>
-                <div>
-                  <label for="admin-create-last-name" class="form-label">Nom</label>
-                  <input type="text" id="admin-create-last-name" class="form-input" required />
-                </div>
-                <div class="md:col-span-2">
-                  <label for="admin-create-password" class="form-label">Mot de passe</label>
-                  <input
-                    type="password"
-                    id="admin-create-password"
-                    class="form-input"
-                    placeholder="Définissez un mot de passe"
-                    autocomplete="new-password"
-                    required
-                  />
-                  <p class="text-xs text-gray-500 mt-1">Aucune contrainte particulière, choisissez un mot de passe simple à retenir.</p>
-                </div>
-                <div id="admin-identifier-preview" class="md:col-span-2 text-sm text-gray-600 hidden">
-                  Identifiant généré :
-                  <span id="admin-identifier-preview-value" class="font-semibold font-mono"></span>
-                </div>
-                <div class="md:col-span-2 flex justify-end">
-                  <button type="submit" class="btn-admin">
-                    <i class="fas fa-user-plus mr-2"></i> Créer et se connecter
-                  </button>
-                </div>
-              </form>
-            </section>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="driver-password-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal__dialog max-w-sm">
+        <div class="p-6">
+          <div class="flex justify-between items-start mb-4">
+            <div>
+              <h3 class="text-xl font-semibold text-gray-800">Mot de passe chauffeur</h3>
+              <p class="text-sm text-gray-500">
+                Merci de saisir le mot de passe pour <span id="driver-password-name" class="font-semibold"></span>.
+              </p>
+            </div>
+            <button id="driver-password-cancel" class="text-gray-400 hover:text-gray-600">
+              <i class="fas fa-times"></i>
+              <span class="sr-only">Annuler</span>
+            </button>
+          </div>
+          <form id="driver-password-form" class="space-y-4">
+            <div>
+              <label for="driver-password-input" class="form-label">Mot de passe</label>
+              <input type="password" id="driver-password-input" class="form-input" autocomplete="current-password" required />
+            </div>
+            <p id="driver-password-error" class="text-sm text-red-600 hidden"></p>
+            <div class="flex justify-end">
+              <button type="submit" class="btn-primary">
+                <i class="fas fa-unlock-keyhole mr-2"></i> Se connecter
+              </button>
+            </div>
+          </form>
         </div>
       </div>
     </div>
@@ -299,27 +291,39 @@
 
         <div id="admin-planning-view" class="space-y-6">
           <section class="bg-white p-4 rounded-lg shadow-sm">
-            <h2 class="text-lg font-semibold text-gray-800">Gestion des chauffeurs</h2>
-            <form id="driver-management-form" class="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4">
-              <div>
-                <label class="form-label" for="driver-first-name">Prénom</label>
-                <input type="text" id="driver-first-name" class="form-input" required />
-              </div>
-              <div>
-                <label class="form-label" for="driver-last-name">Nom</label>
-                <input type="text" id="driver-last-name" class="form-input" required />
-              </div>
-              <div>
-                <label class="form-label" for="driver-email">Email (facultatif)</label>
-                <input type="email" id="driver-email" class="form-input" placeholder="prenom.nom@agriholann.com" />
-              </div>
-              <div class="md:col-span-1 flex items-end">
-                <button type="submit" class="btn-primary w-full md:w-auto">
-                  <i class="fas fa-user-plus mr-2"></i> Ajouter
-                </button>
-              </div>
-            </form>
-            <div id="driver-management-list" class="mt-4"></div>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <h2 class="text-lg font-semibold text-gray-800">Gestion des chauffeurs</h2>
+              <button
+                id="driver-management-toggle"
+                type="button"
+                class="btn-tertiary text-sm"
+                aria-expanded="false"
+              >
+                <i class="fas fa-users-cog mr-2"></i> Afficher la gestion des chauffeurs
+              </button>
+            </div>
+            <div id="driver-management-panel" class="mt-4 hidden space-y-4">
+              <form id="driver-management-form" class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div>
+                  <label class="form-label" for="driver-first-name">Prénom</label>
+                  <input type="text" id="driver-first-name" class="form-input" required />
+                </div>
+                <div>
+                  <label class="form-label" for="driver-last-name">Nom</label>
+                  <input type="text" id="driver-last-name" class="form-input" required />
+                </div>
+                <div>
+                  <label class="form-label" for="driver-email">Email (facultatif)</label>
+                  <input type="email" id="driver-email" class="form-input" placeholder="prenom.nom@agriholann.com" />
+                </div>
+                <div class="md:col-span-1 flex items-end">
+                  <button type="submit" class="btn-primary w-full md:w-auto">
+                    <i class="fas fa-user-plus mr-2"></i> Ajouter
+                  </button>
+                </div>
+              </form>
+              <div id="driver-management-list" class="mt-4"></div>
+            </div>
           </section>
 
           <section class="bg-white p-4 rounded-lg shadow-sm space-y-4">
@@ -452,73 +456,100 @@
         </div>
 
         <div id="admin-settings-view" class="hidden space-y-6">
-          <section class="bg-white p-4 rounded-lg shadow-sm max-w-xl">
-            <h2 class="text-lg font-semibold text-gray-800">Paramètres email</h2>
-            <form id="email-settings-form" class="space-y-4 mt-4">
-              <div class="space-y-4">
+          <section class="bg-white p-4 rounded-lg shadow-sm max-w-4xl">
+            <div class="flex flex-wrap items-center gap-2 border-b border-gray-200 pb-3 mb-4">
+              <button type="button" class="settings-tab settings-tab--active" data-settings-tab="email">
+                Configuration email
+              </button>
+              <button type="button" class="settings-tab" data-settings-tab="drivers">
+                Accès chauffeurs
+              </button>
+              <button type="button" class="settings-tab" data-settings-tab="admins">
+                Administrateurs
+              </button>
+            </div>
+
+            <div data-settings-panel="email" class="space-y-4">
+              <h3 class="text-lg font-semibold text-gray-800">Adresse de réception</h3>
+              <form id="email-settings-form" class="space-y-4">
                 <div>
                   <label class="form-label" for="email-recipient">Adresse email de réception</label>
                   <input type="email" id="email-recipient" class="form-input" required />
+                  <p class="text-xs text-gray-500 mt-1">Les récapitulatifs de courses sont envoyés à cette adresse.</p>
                 </div>
-                <div class="border-t border-gray-200 pt-4">
-                  <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
-                    Identifiants Gmail
-                  </h3>
-                  <p class="text-sm text-gray-500 mt-1">
-                    Renseignez les informations OAuth fournies par Google pour autoriser l'envoi des mails.
-                  </p>
+                <div class="flex justify-end">
+                  <button type="submit" class="btn-primary">
+                    <i class="fas fa-save mr-2"></i> Enregistrer
+                  </button>
+                </div>
+              </form>
+              <p id="email-settings-status" class="text-sm mt-2 hidden"></p>
+            </div>
+
+            <div data-settings-panel="drivers" class="space-y-4 hidden">
+              <h3 class="text-lg font-semibold text-gray-800">Mots de passe chauffeurs</h3>
+              <p class="text-sm text-gray-500">
+                Définissez, modifiez ou supprimez les mots de passe des chauffeurs. Lorsqu'un mot de passe est défini, il sera demandé à la connexion.
+              </p>
+              <div id="driver-password-list" class="space-y-3"></div>
+              <p id="driver-password-empty" class="text-sm text-gray-500 hidden">Aucun chauffeur enregistré.</p>
+            </div>
+
+            <div data-settings-panel="admins" class="space-y-4 hidden">
+              <h3 class="text-lg font-semibold text-gray-800">Gestion des administrateurs</h3>
+              <p class="text-sm text-gray-500">
+                Seul Laurent Saquet (super administrateur) peut créer ou supprimer des comptes administrateurs.
+              </p>
+              <form id="admin-management-create-form" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label for="admin-management-first-name" class="form-label">Prénom</label>
+                  <input type="text" id="admin-management-first-name" class="form-input" required />
                 </div>
                 <div>
-                  <label class="form-label" for="gmail-client-id">Client ID</label>
-                  <input
-                    type="text"
-                    id="gmail-client-id"
-                    class="form-input"
-                    autocomplete="off"
-                    spellcheck="false"
-                    required
-                  />
+                  <label for="admin-management-last-name" class="form-label">Nom</label>
+                  <input type="text" id="admin-management-last-name" class="form-input" required />
                 </div>
                 <div>
-                  <label class="form-label" for="gmail-client-secret">Client secret</label>
-                  <input
-                    type="password"
-                    id="gmail-client-secret"
-                    class="form-input"
-                    autocomplete="new-password"
-                    required
-                  />
+                  <label for="admin-management-password" class="form-label">Mot de passe</label>
+                  <input type="password" id="admin-management-password" class="form-input" autocomplete="new-password" required />
                 </div>
                 <div>
-                  <label class="form-label" for="gmail-refresh-token">Refresh token</label>
-                  <input
-                    type="password"
-                    id="gmail-refresh-token"
-                    class="form-input"
-                    autocomplete="new-password"
-                    required
-                  />
+                  <label for="admin-management-role" class="form-label">Niveau d'accès</label>
+                  <select id="admin-management-role" class="form-input">
+                    <option value="manager">Gestion</option>
+                    <option value="standard">Standard</option>
+                  </select>
                 </div>
-                <div>
-                  <label class="form-label" for="gmail-redirect-uri">Redirect URI</label>
-                  <input
-                    type="text"
-                    id="gmail-redirect-uri"
-                    class="form-input"
-                    autocomplete="off"
-                    spellcheck="false"
-                    placeholder="http://localhost"
-                    required
-                  />
+                <div class="md:col-span-2 flex justify-end">
+                  <button type="submit" class="btn-admin">
+                    <i class="fas fa-user-plus mr-2"></i> Ajouter un administrateur
+                  </button>
                 </div>
+              </form>
+              <p id="admin-management-status" class="text-sm mt-2 hidden"></p>
+              <div id="admin-management-list" class="space-y-3"></div>
+
+              <div class="border-t border-gray-200 pt-4">
+                <h4 class="text-base font-semibold text-gray-800">Changer mon mot de passe</h4>
+                <form id="admin-password-form" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
+                  <div class="md:col-span-2">
+                    <label for="admin-password-current" class="form-label">Mot de passe actuel</label>
+                    <input type="password" id="admin-password-current" class="form-input" autocomplete="current-password" />
+                    <p class="text-xs text-gray-500 mt-1">Obligatoire si un mot de passe est déjà défini.</p>
+                  </div>
+                  <div class="md:col-span-2">
+                    <label for="admin-password-new" class="form-label">Nouveau mot de passe</label>
+                    <input type="password" id="admin-password-new" class="form-input" autocomplete="new-password" required />
+                  </div>
+                  <div class="md:col-span-2 flex justify-end">
+                    <button type="submit" class="btn-primary">
+                      <i class="fas fa-key mr-2"></i> Mettre à jour
+                    </button>
+                  </div>
+                </form>
+                <p id="admin-password-feedback" class="text-sm mt-2 hidden"></p>
               </div>
-              <div class="flex justify-end">
-                <button type="submit" class="btn-primary">
-                  <i class="fas fa-save mr-2"></i> Enregistrer
-                </button>
-              </div>
-            </form>
-            <p id="email-settings-status" class="text-sm mt-2 hidden"></p>
+            </div>
           </section>
         </div>
       </main>

--- a/index.html
+++ b/index.html
@@ -455,9 +455,62 @@
           <section class="bg-white p-4 rounded-lg shadow-sm max-w-xl">
             <h2 class="text-lg font-semibold text-gray-800">Paramètres email</h2>
             <form id="email-settings-form" class="space-y-4 mt-4">
-              <div>
-                <label class="form-label" for="email-recipient">Adresse email de réception</label>
-                <input type="email" id="email-recipient" class="form-input" required />
+              <div class="space-y-4">
+                <div>
+                  <label class="form-label" for="email-recipient">Adresse email de réception</label>
+                  <input type="email" id="email-recipient" class="form-input" required />
+                </div>
+                <div class="border-t border-gray-200 pt-4">
+                  <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                    Identifiants Gmail
+                  </h3>
+                  <p class="text-sm text-gray-500 mt-1">
+                    Renseignez les informations OAuth fournies par Google pour autoriser l'envoi des mails.
+                  </p>
+                </div>
+                <div>
+                  <label class="form-label" for="gmail-client-id">Client ID</label>
+                  <input
+                    type="text"
+                    id="gmail-client-id"
+                    class="form-input"
+                    autocomplete="off"
+                    spellcheck="false"
+                    required
+                  />
+                </div>
+                <div>
+                  <label class="form-label" for="gmail-client-secret">Client secret</label>
+                  <input
+                    type="password"
+                    id="gmail-client-secret"
+                    class="form-input"
+                    autocomplete="new-password"
+                    required
+                  />
+                </div>
+                <div>
+                  <label class="form-label" for="gmail-refresh-token">Refresh token</label>
+                  <input
+                    type="password"
+                    id="gmail-refresh-token"
+                    class="form-input"
+                    autocomplete="new-password"
+                    required
+                  />
+                </div>
+                <div>
+                  <label class="form-label" for="gmail-redirect-uri">Redirect URI</label>
+                  <input
+                    type="text"
+                    id="gmail-redirect-uri"
+                    class="form-input"
+                    autocomplete="off"
+                    spellcheck="false"
+                    placeholder="http://localhost"
+                    required
+                  />
+                </div>
               </div>
               <div class="flex justify-end">
                 <button type="submit" class="btn-primary">

--- a/index.html
+++ b/index.html
@@ -61,27 +61,22 @@
       class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 hidden"
       aria-hidden="true"
     >
-      <div class="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto slide-in">
+      <div class="relative bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto slide-in">
+        <button
+          id="close-admin-login"
+          class="absolute top-4 right-4 text-gray-400 hover:text-gray-600 text-2xl"
+          title="Fermer l'accès administration"
+        >
+          <i class="fas fa-times"></i>
+          <span class="sr-only">Fermer la fenêtre d'authentification</span>
+        </button>
         <div class="p-6">
-          <div class="flex justify-between items-start mb-4">
-            <div>
-              <h3 class="text-xl font-semibold text-gray-800">Accès administration</h3>
-              <p class="text-sm text-gray-500">
-                Connectez-vous avec votre identifiant administrateur. Pour toute création de compte, contactez Laurent Saquet.
-              </p>
-            </div>
-            <button id="close-admin-login" class="text-gray-400 hover:text-gray-600 text-2xl" title="Fermer l'accès administration">
-              <i class="fas fa-times"></i>
-              <span class="sr-only">Fermer la fenêtre d'authentification</span>
-            </button>
-          </div>
-
           <div class="space-y-8">
             <section class="space-y-4">
               <div>
-                <h4 class="text-lg font-semibold text-gray-800">Se connecter</h4>
+                <h3 class="text-xl font-semibold text-gray-800">Accès administration</h3>
                 <p class="text-sm text-gray-500">
-                  Identifiant attendu : initiale du prénom suivie du nom de famille (ex. jdupont).
+                  Connectez-vous avec votre identifiant administrateur. Pour toute création de compte, contactez Laurent Saquet.
                 </p>
               </div>
               <form id="admin-login-form" class="space-y-3">
@@ -111,12 +106,7 @@
                   <i class="fas fa-right-to-bracket mr-2"></i> Se connecter
                 </button>
               </form>
-              <div>
-                <h5 class="text-sm font-semibold text-gray-700 mb-2">Comptes disponibles</h5>
-                <div id="admin-accounts" class="space-y-2"></div>
-              </div>
             </section>
-
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -203,6 +203,27 @@
           </button>
         </div>
 
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-gray-600">Affichage</span>
+            <div class="flex gap-2">
+              <button type="button" class="filter-chip" data-driver-layout="cards">
+                <i class="fas fa-th-large mr-1"></i> Cartes
+              </button>
+              <button type="button" class="filter-chip" data-driver-layout="list">
+                <i class="fas fa-list mr-1"></i> Liste
+              </button>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-gray-600">Lisibilité</span>
+            <div class="flex gap-2">
+              <button type="button" class="filter-chip" data-driver-density="comfortable">Standard</button>
+              <button type="button" class="filter-chip" data-driver-density="contrast">Contraste</button>
+            </div>
+          </div>
+        </div>
+
         <div id="today-courses">
           <h2 class="section-title">Vos courses aujourd'hui</h2>
           <div id="today-list" class="space-y-3"></div>
@@ -352,23 +373,94 @@
           </section>
 
           <section class="bg-white p-4 rounded-lg shadow-sm space-y-4">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+            <div class="grid grid-cols-1 xl:grid-cols-4 gap-4">
               <div>
-                <label class="form-label" for="admin-driver-select">Filtrer par chauffeur</label>
+                <label class="form-label" for="admin-driver-select">Chauffeur</label>
                 <select id="admin-driver-select" class="form-input">
                   <option value="all">Tous les chauffeurs</option>
                 </select>
               </div>
               <div>
+                <label class="form-label" for="admin-status-filter">Statut</label>
+                <select id="admin-status-filter" class="form-input">
+                  <option value="all">Tous les statuts</option>
+                  <option value="pending">À faire</option>
+                  <option value="completed">Terminées</option>
+                  <option value="issue_reported">Signalements</option>
+                </select>
+              </div>
+              <div>
+                <label class="form-label" for="admin-merchandise-filter">Marchandise</label>
+                <select id="admin-merchandise-filter" class="form-input">
+                  <option value="all">Toutes</option>
+                  <option value="Céréales">Céréales</option>
+                  <option value="Légumes">Légumes</option>
+                  <option value="Fruits">Fruits</option>
+                  <option value="Engrais">Engrais</option>
+                  <option value="Autre">Autre</option>
+                </select>
+              </div>
+              <div>
+                <label class="form-label" for="admin-search-filter">Recherche</label>
+                <input
+                  type="search"
+                  id="admin-search-filter"
+                  class="form-input"
+                  placeholder="Départ, destination, commentaire..."
+                />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-1 xl:grid-cols-4 gap-4 items-end">
+              <div>
                 <span class="form-label">Période</span>
                 <div class="flex flex-wrap gap-2 mt-2">
                   <button type="button" class="filter-chip" data-admin-range="day">Aujourd'hui</button>
                   <button type="button" class="filter-chip" data-admin-range="week">7 jours</button>
+                  <button type="button" class="filter-chip" data-admin-range="month">30 jours</button>
+                  <button type="button" class="filter-chip" data-admin-range="custom">Personnalisé</button>
                   <button type="button" class="filter-chip" data-admin-range="all">Tout afficher</button>
                 </div>
               </div>
-              <div class="flex md:justify-end">
-                <button id="new-course-admin" class="btn-admin w-full md:w-auto">
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label class="form-label" for="admin-from">Du</label>
+                  <input type="date" id="admin-from" class="form-input" />
+                </div>
+                <div>
+                  <label class="form-label" for="admin-to">Au</label>
+                  <input type="date" id="admin-to" class="form-input" />
+                </div>
+              </div>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label class="form-label" for="admin-issue-filter">Problèmes</label>
+                  <select id="admin-issue-filter" class="form-input">
+                    <option value="all">Toutes les courses</option>
+                    <option value="issues">Uniquement les signalements</option>
+                    <option value="clear">Aucun problème</option>
+                  </select>
+                </div>
+                <div>
+                  <label class="form-label" for="admin-photo-filter">Photos</label>
+                  <select id="admin-photo-filter" class="form-input">
+                    <option value="all">Toutes</option>
+                    <option value="with">Avec photo</option>
+                    <option value="without">Sans photo</option>
+                  </select>
+                </div>
+              </div>
+              <div class="flex flex-wrap gap-2 justify-end">
+                <button id="admin-reset-filters" class="btn-tertiary text-sm">
+                  <i class="fas fa-undo mr-1"></i> Réinitialiser
+                </button>
+                <button id="admin-export-pdf" class="btn-secondary text-sm">
+                  <i class="fas fa-file-pdf mr-1"></i> Export PDF
+                </button>
+                <button id="admin-export-excel" class="btn-secondary text-sm">
+                  <i class="fas fa-file-excel mr-1"></i> Export Excel
+                </button>
+                <button id="new-course-admin" class="btn-admin">
                   <i class="fas fa-plus mr-1"></i> Nouvelle course
                 </button>
               </div>
@@ -376,8 +468,31 @@
           </section>
 
           <section>
-            <h2 class="section-title">Planning des courses</h2>
-            <div class="overflow-x-auto">
+            <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <h2 class="section-title mb-0">Planning des courses</h2>
+              <div class="flex flex-wrap gap-4 items-center">
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-medium text-gray-600">Affichage</span>
+                  <div class="flex gap-2">
+                    <button type="button" class="filter-chip" data-admin-layout="table">
+                      <i class="fas fa-table mr-1"></i> Tableau
+                    </button>
+                    <button type="button" class="filter-chip" data-admin-layout="cards">
+                      <i class="fas fa-layer-group mr-1"></i> Cartes
+                    </button>
+                  </div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-medium text-gray-600">Lisibilité</span>
+                  <div class="flex gap-2">
+                    <button type="button" class="filter-chip" data-admin-density="comfortable">Standard</button>
+                    <button type="button" class="filter-chip" data-admin-density="contrast">Contraste</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div id="admin-table-wrapper" class="overflow-x-auto">
               <table class="responsive-table min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                   <tr>
@@ -393,6 +508,7 @@
                 <tbody id="admin-week-list" class="bg-white divide-y divide-gray-200"></tbody>
               </table>
             </div>
+            <div id="admin-card-list" class="grid gap-4 hidden"></div>
             <div id="no-courses-admin" class="empty-state hidden">
               <i class="fas fa-calendar-week text-4xl mb-3 opacity-30"></i>
               <p>Aucune course prévue</p>
@@ -454,6 +570,14 @@
                   <input type="date" id="archive-to" class="form-input" />
                 </div>
               </div>
+            </div>
+            <div class="flex flex-wrap gap-2 justify-end">
+              <button id="archive-export-pdf" class="btn-secondary text-sm">
+                <i class="fas fa-file-pdf mr-1"></i> Export PDF
+              </button>
+              <button id="archive-export-excel" class="btn-secondary text-sm">
+                <i class="fas fa-file-excel mr-1"></i> Export Excel
+              </button>
             </div>
           </section>
 
@@ -633,6 +757,21 @@
             </button>
           </div>
           <div class="mb-4">
+            <div class="flex flex-wrap items-center justify-between mb-3 gap-2">
+              <div class="flex items-center gap-2 text-sm text-gray-600">
+                <i class="fas fa-sync-alt text-gray-400"></i>
+                <span>Sélectionner la caméra</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <button id="switch-camera" type="button" class="btn-tertiary text-sm">
+                  <i class="fas fa-exchange-alt mr-2"></i> Inverser
+                </button>
+                <select id="camera-facing-select" class="form-input text-sm w-40">
+                  <option value="environment">Caméra arrière</option>
+                  <option value="user">Caméra avant</option>
+                </select>
+              </div>
+            </div>
             <div class="bg-gray-100 rounded-md h-64 flex items-center justify-center mb-3">
               <video id="camera" class="w-full h-full object-cover rounded-md hidden" playsinline></video>
               <canvas id="canvas" class="hidden"></canvas>

--- a/index.html
+++ b/index.html
@@ -485,59 +485,87 @@
               <p id="driver-password-empty" class="text-sm text-gray-500 hidden">Aucun chauffeur enregistré.</p>
             </div>
 
-            <div data-settings-panel="admins" class="space-y-4 hidden">
-              <h3 class="text-lg font-semibold text-gray-800">Gestion des administrateurs</h3>
-              <p class="text-sm text-gray-500">
-                Seul Laurent Saquet (super administrateur) peut créer ou supprimer des comptes administrateurs.
-              </p>
-              <form id="admin-management-create-form" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label for="admin-management-first-name" class="form-label">Prénom</label>
-                  <input type="text" id="admin-management-first-name" class="form-input" required />
-                </div>
-                <div>
-                  <label for="admin-management-last-name" class="form-label">Nom</label>
-                  <input type="text" id="admin-management-last-name" class="form-input" required />
-                </div>
-                <div>
-                  <label for="admin-management-password" class="form-label">Mot de passe</label>
-                  <input type="password" id="admin-management-password" class="form-input" autocomplete="new-password" required />
-                </div>
-                <div>
-                  <label for="admin-management-role" class="form-label">Niveau d'accès</label>
-                  <select id="admin-management-role" class="form-input">
-                    <option value="manager">Gestion</option>
-                    <option value="standard">Standard</option>
-                  </select>
-                </div>
-                <div class="md:col-span-2 flex justify-end">
-                  <button type="submit" class="btn-admin">
-                    <i class="fas fa-user-plus mr-2"></i> Ajouter un administrateur
-                  </button>
-                </div>
-              </form>
-              <p id="admin-management-status" class="text-sm mt-2 hidden"></p>
-              <div id="admin-management-list" class="space-y-3"></div>
+            <div id="admin-management-panel" data-settings-panel="admins" class="space-y-4 hidden">
+              <div class="space-y-1">
+                <h3 class="text-lg font-semibold text-gray-800">Gestion des administrateurs</h3>
+                <p class="text-sm text-gray-500">
+                  Seul Laurent Saquet (super administrateur) peut créer ou supprimer des comptes administrateurs.
+                </p>
+              </div>
 
-              <div class="border-t border-gray-200 pt-4">
-                <h4 class="text-base font-semibold text-gray-800">Changer mon mot de passe</h4>
-                <form id="admin-password-form" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
-                  <div class="md:col-span-2">
-                    <label for="admin-password-current" class="form-label">Mot de passe actuel</label>
-                    <input type="password" id="admin-password-current" class="form-input" autocomplete="current-password" />
-                    <p class="text-xs text-gray-500 mt-1">Obligatoire si un mot de passe est déjà défini.</p>
+              <div class="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  class="admin-management-tab admin-management-tab--active"
+                  data-admin-management-tab="list"
+                  aria-selected="true"
+                >
+                  Liste des administrateurs
+                </button>
+                <button
+                  type="button"
+                  class="admin-management-tab"
+                  data-admin-management-tab="create"
+                  aria-selected="false"
+                >
+                  Créer un administrateur
+                </button>
+              </div>
+
+              <p id="admin-management-status" class="text-sm mt-2 hidden"></p>
+
+              <div data-admin-management-panel="list" class="space-y-3">
+                <div id="admin-management-list" class="space-y-3"></div>
+              </div>
+
+              <div data-admin-management-panel="create" class="space-y-4 hidden">
+                <form id="admin-management-create-form" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label for="admin-management-first-name" class="form-label">Prénom</label>
+                    <input type="text" id="admin-management-first-name" class="form-input" required />
                   </div>
-                  <div class="md:col-span-2">
-                    <label for="admin-password-new" class="form-label">Nouveau mot de passe</label>
-                    <input type="password" id="admin-password-new" class="form-input" autocomplete="new-password" required />
+                  <div>
+                    <label for="admin-management-last-name" class="form-label">Nom</label>
+                    <input type="text" id="admin-management-last-name" class="form-input" required />
+                  </div>
+                  <div>
+                    <label for="admin-management-password" class="form-label">Mot de passe</label>
+                    <input type="password" id="admin-management-password" class="form-input" autocomplete="new-password" required />
+                  </div>
+                  <div>
+                    <label for="admin-management-role" class="form-label">Niveau d'accès</label>
+                    <select id="admin-management-role" class="form-input">
+                      <option value="manager">Gestion</option>
+                      <option value="standard">Standard</option>
+                    </select>
                   </div>
                   <div class="md:col-span-2 flex justify-end">
-                    <button type="submit" class="btn-primary">
-                      <i class="fas fa-key mr-2"></i> Mettre à jour
+                    <button type="submit" class="btn-admin">
+                      <i class="fas fa-user-plus mr-2"></i> Ajouter un administrateur
                     </button>
                   </div>
                 </form>
-                <p id="admin-password-feedback" class="text-sm mt-2 hidden"></p>
+
+                <div class="border-t border-gray-200 pt-4">
+                  <h4 class="text-base font-semibold text-gray-800">Changer mon mot de passe</h4>
+                  <form id="admin-password-form" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
+                    <div class="md:col-span-2">
+                      <label for="admin-password-current" class="form-label">Mot de passe actuel</label>
+                      <input type="password" id="admin-password-current" class="form-input" autocomplete="current-password" />
+                      <p class="text-xs text-gray-500 mt-1">Obligatoire si un mot de passe est déjà défini.</p>
+                    </div>
+                    <div class="md:col-span-2">
+                      <label for="admin-password-new" class="form-label">Nouveau mot de passe</label>
+                      <input type="password" id="admin-password-new" class="form-input" autocomplete="new-password" required />
+                    </div>
+                    <div class="md:col-span-2 flex justify-end">
+                      <button type="submit" class="btn-primary">
+                        <i class="fas fa-key mr-2"></i> Mettre à jour
+                      </button>
+                    </div>
+                  </form>
+                  <p id="admin-password-feedback" class="text-sm mt-2 hidden"></p>
+                </div>
               </div>
             </div>
           </section>

--- a/index.html
+++ b/index.html
@@ -294,6 +294,7 @@
         <div class="flex border-b border-gray-200">
           <button id="admin-planning-tab" class="admin-tab admin-tab--active">Planning</button>
           <button id="admin-archives-tab" class="admin-tab">Archives</button>
+          <button id="admin-settings-tab" class="admin-tab">Paramètres</button>
         </div>
 
         <div id="admin-planning-view" class="space-y-6">
@@ -447,6 +448,24 @@
               <i class="fas fa-box-archive text-4xl mb-3 opacity-30"></i>
               <p>Aucune course archivée pour ces critères</p>
             </div>
+          </section>
+        </div>
+
+        <div id="admin-settings-view" class="hidden space-y-6">
+          <section class="bg-white p-4 rounded-lg shadow-sm max-w-xl">
+            <h2 class="text-lg font-semibold text-gray-800">Paramètres email</h2>
+            <form id="email-settings-form" class="space-y-4 mt-4">
+              <div>
+                <label class="form-label" for="email-recipient">Adresse email de réception</label>
+                <input type="email" id="email-recipient" class="form-input" required />
+              </div>
+              <div class="flex justify-end">
+                <button type="submit" class="btn-primary">
+                  <i class="fas fa-save mr-2"></i> Enregistrer
+                </button>
+              </div>
+            </form>
+            <p id="email-settings-status" class="text-sm mt-2 hidden"></p>
           </section>
         </div>
       </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "express": "^4.19.2",
-        "nodemailer": "^6.9.8",
+        "googleapis": "^136.0.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7"
       },
@@ -235,6 +235,15 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -339,6 +348,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -607,6 +622,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -778,6 +802,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -903,6 +933,81 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -981,6 +1086,62 @@
         "node": ">= 6"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "136.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-136.0.0.tgz",
+      "integrity": "sha512-W2Z1NtFS8ie5SzN74+lnTzLS9d0tS01dybibqXjWKSfdvTkQr9DYsKYNMRpzMAcBva1ZWCAgTiX4fgGz2Cwbaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -999,6 +1160,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1325,12 +1499,54 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1628,6 +1844,26 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -1651,15 +1887,6 @@
       },
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -2551,6 +2778,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2612,6 +2845,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2627,6 +2866,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2634,6 +2886,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,44 @@
       "dependencies": {
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
+        "exceljs": "^4.4.0",
         "express": "^4.19.2",
         "googleapis": "^136.0.0",
+        "pdfkit": "^0.15.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
         "nodemon": "^3.0.3"
+      }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -52,6 +83,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -61,6 +101,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -178,6 +224,81 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -193,17 +314,53 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -235,11 +392,33 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
       "engines": {
         "node": "*"
       }
@@ -277,6 +456,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -305,7 +490,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -323,6 +507,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/buffer": {
@@ -349,11 +542,37 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -394,6 +613,24 @@
         "node": ">= 10"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -421,6 +658,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -467,6 +716,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -477,11 +735,25 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/console-control-strings": {
@@ -527,6 +799,12 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -539,6 +817,43 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -564,6 +879,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -571,6 +918,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delegates": {
@@ -608,6 +989,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -620,6 +1007,51 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -720,6 +1152,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -745,6 +1197,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expand-template": {
@@ -808,6 +1289,19 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -843,6 +1337,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -885,8 +1411,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -903,10 +1428,60 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1057,7 +1632,6 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1158,8 +1732,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/gtoken": {
       "version": "7.1.0",
@@ -1174,6 +1747,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1184,11 +1769,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1366,6 +1978,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1399,7 +2017,6 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1416,6 +2033,20 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -1436,6 +2067,54 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1447,6 +2126,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -1489,6 +2212,18 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1497,6 +2232,67 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -1511,12 +2307,85 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -1525,6 +2394,54 @@
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/jwa": {
@@ -1547,6 +2464,167 @@
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1674,7 +2752,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1963,7 +3040,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2000,6 +3076,51 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2044,6 +3165,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2058,7 +3185,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2068,6 +3194,19 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2080,6 +3219,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/prebuild-install": {
@@ -2107,6 +3260,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -2227,6 +3386,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2239,6 +3428,32 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -2287,11 +3502,40 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -2365,6 +3609,44 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2627,6 +3909,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2746,6 +4041,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2784,6 +4094,21 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2816,6 +4141,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -2843,6 +4194,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/url-template": {
@@ -2920,6 +4325,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -2936,11 +4399,52 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "init-db": "node scripts/init-db.js"
+    "init-db": "node scripts/init-db.js",
+    "create-gmail-token": "node scripts/create-token-json.js"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "nodemailer": "^6.9.8",
+    "googleapis": "^136.0.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "exceljs": "^4.4.0",
     "googleapis": "^136.0.0",
+    "pdfkit": "^0.15.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7"
   },

--- a/scripts/create-token-json.js
+++ b/scripts/create-token-json.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function printUsage() {
+  console.log(`Usage: node scripts/create-token-json.js --refresh-token=<token> [--output=token.json] [--force]\n`);
+  console.log('Options:');
+  console.log('  --refresh-token  Jeton d\'actualisation généré via OAuth2 (obligatoire).');
+  console.log('  --output         Emplacement du fichier token.json à générer (défaut : ./token.json).');
+  console.log('  --force          Écrase le fichier existant le cas échéant.');
+}
+
+function parseArgs(argv) {
+  const result = {
+    refreshToken: process.env.GMAIL_REFRESH_TOKEN || '',
+    output: path.resolve(__dirname, '..', 'token.json'),
+    force: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+      return result;
+    }
+
+    if (arg === '--force') {
+      result.force = true;
+      continue;
+    }
+
+    if (arg.startsWith('--refresh-token=')) {
+      result.refreshToken = arg.split('=')[1];
+      continue;
+    }
+
+    if (arg.startsWith('--output=')) {
+      const value = arg.split('=')[1];
+      if (value) {
+        result.output = path.resolve(process.cwd(), value);
+      }
+      continue;
+    }
+  }
+
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (!args.refreshToken) {
+    console.error("⚠️  Aucun refresh_token fourni. Utilisez --refresh-token=<token> ou définissez GMAIL_REFRESH_TOKEN.");
+    printUsage();
+    process.exit(1);
+  }
+
+  const trimmedToken = args.refreshToken.trim();
+  if (!trimmedToken) {
+    console.error('⚠️  Le refresh_token est vide après suppression des espaces.');
+    process.exit(1);
+  }
+
+  const outputDir = path.dirname(args.output);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  if (fs.existsSync(args.output) && !args.force) {
+    console.error(`⚠️  Le fichier ${args.output} existe déjà. Utilisez --force pour l\'écraser.`);
+    process.exit(1);
+  }
+
+  const content = {
+    refresh_token: trimmedToken,
+  };
+
+  fs.writeFileSync(args.output, `${JSON.stringify(content, null, 2)}\n`, 'utf8');
+
+  console.log(`✅ Fichier token.json généré : ${args.output}`);
+}
+
+main().catch((error) => {
+  console.error('❌ Impossible de créer token.json :', error.message);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -1296,15 +1296,40 @@ app.post('/api/admins/logout', (req, res) => {
   res.status(204).send();
 });
 
+app.get('/api/drivers/credentials', async (req, res) => {
+  try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const drivers = await db.all(
+      "SELECT id, first_name, last_name, email, phone, CASE WHEN password_hash IS NULL OR TRIM(password_hash) = '' THEN 0 ELSE 1 END AS has_password FROM drivers ORDER BY last_name ASC, first_name ASC"
+    );
+
+    res.json(drivers);
+  } catch (error) {
+    console.error('Error fetching driver credentials', error);
+    res.status(500).json({ message: 'Erreur lors de la récupération des mots de passe chauffeurs' });
+  }
+});
+
 app.get('/api/drivers/:id', async (req, res) => {
   try {
+    const driverId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(driverId)) {
+      return res.status(400).json({ message: 'Identifiant chauffeur invalide.' });
+    }
+
     const driver = await db.get(
       "SELECT id, first_name, last_name, email, phone, CASE WHEN password_hash IS NULL OR TRIM(password_hash) = '' THEN 0 ELSE 1 END AS has_password FROM drivers WHERE id = ?",
-      [req.params.id]
+      [driverId]
     );
 
     if (!driver) {
-      return res.status(404).json({ message: 'Chauffeur introuvable' });
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
     }
 
     res.json(driver);
@@ -1354,26 +1379,6 @@ app.post('/api/drivers/login', async (req, res) => {
   } catch (error) {
     console.error('Error validating driver login', error);
     res.status(500).json({ message: 'Erreur lors de la vérification du mot de passe chauffeur' });
-  }
-});
-
-app.get('/api/drivers/credentials', async (req, res) => {
-  try {
-    const sessionInfo = await enforceAdminSession(req, res, {
-      allowRoles: Array.from(ADMIN_ROLES),
-    });
-    if (!sessionInfo) {
-      return;
-    }
-
-    const drivers = await db.all(
-      "SELECT id, first_name, last_name, email, phone, CASE WHEN password_hash IS NULL OR TRIM(password_hash) = '' THEN 0 ELSE 1 END AS has_password FROM drivers ORDER BY last_name ASC, first_name ASC"
-    );
-
-    res.json(drivers);
-  } catch (error) {
-    console.error('Error fetching driver credentials', error);
-    res.status(500).json({ message: 'Erreur lors de la récupération des mots de passe chauffeurs' });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ const sqlite3 = require('sqlite3').verbose();
 const { open } = require('sqlite');
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
+const PDFDocument = require('pdfkit');
+const ExcelJS = require('exceljs');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -97,9 +99,215 @@ const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
 const COURSE_STATUS_PENDING = 'pending';
 const COURSE_STATUS_COMPLETED = 'completed';
 const COURSE_STATUS_ISSUE_REPORTED = 'issue_reported';
+const COURSE_STATUSES = new Set([
+  COURSE_STATUS_PENDING,
+  COURSE_STATUS_COMPLETED,
+  COURSE_STATUS_ISSUE_REPORTED,
+]);
 
 const activeAdminSessions = new Map();
 const sseClients = new Set();
+
+function parseBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function normalizeArrayParam(value) {
+  if (!value && value !== 0) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === 'string' ? item.trim() : String(item)))
+      .filter(Boolean);
+  }
+  return String(value)
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function mapCourseRow(row, options = {}) {
+  const { includePhotoPath = false } = options;
+
+  const mapped = {
+    id: row.id,
+    driverId: row.driver_id,
+    driverName:
+      row.first_name && row.last_name
+        ? `${row.first_name} ${row.last_name}`
+        : row.first_name || row.last_name || null,
+    dateTime: row.date_time,
+    departure: row.departure,
+    destination: row.destination,
+    merchandise: row.merchandise,
+    comments: row.comments,
+    status: row.status,
+    issueReportedAt: row.issue_reported_at,
+    issueReportComment: row.issue_report_comment,
+    issueReportedBy: row.issue_reported_by,
+    photoUrl: row.photo_path ? `/storage/attachments/${path.basename(row.photo_path)}` : null,
+    completionComments: row.completion_comments,
+    archivedAt: row.archived_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+
+  if (includePhotoPath) {
+    mapped.photoPath = row.photo_path || null;
+  }
+
+  return mapped;
+}
+
+function buildCourseQuery(filters = {}) {
+  const conditions = [];
+  const params = [];
+
+  if (filters.id) {
+    conditions.push('c.id = ?');
+    params.push(filters.id);
+  }
+
+  if (filters.driverId) {
+    conditions.push('c.driver_id = ?');
+    params.push(filters.driverId);
+  }
+
+  if (filters.driverIds && filters.driverIds.length) {
+    const placeholders = filters.driverIds.map(() => '?').join(',');
+    conditions.push(`c.driver_id IN (${placeholders})`);
+    params.push(...filters.driverIds);
+  }
+
+  if (filters.archived === 'true') {
+    conditions.push('c.archived_at IS NOT NULL');
+  } else if (filters.archived === 'false') {
+    conditions.push('c.archived_at IS NULL');
+  } else if (!filters.archived || filters.archived === 'pending') {
+    conditions.push('c.archived_at IS NULL');
+  }
+
+  if (filters.from) {
+    const fromDate = new Date(filters.from);
+    if (!Number.isNaN(fromDate.getTime())) {
+      conditions.push('c.date_time >= ?');
+      params.push(fromDate.toISOString());
+    }
+  }
+
+  if (filters.to) {
+    const toDate = new Date(filters.to);
+    if (!Number.isNaN(toDate.getTime())) {
+      conditions.push('c.date_time <= ?');
+      params.push(toDate.toISOString());
+    }
+  }
+
+  if (filters.status) {
+    const statuses = normalizeArrayParam(filters.status).filter((status) => COURSE_STATUSES.has(status));
+    if (statuses.length === 1) {
+      conditions.push('c.status = ?');
+      params.push(statuses[0]);
+    } else if (statuses.length > 1) {
+      const placeholders = statuses.map(() => '?').join(',');
+      conditions.push(`c.status IN (${placeholders})`);
+      params.push(...statuses);
+    }
+  }
+
+  if (filters.merchandise) {
+    const merchValues = normalizeArrayParam(filters.merchandise);
+    if (merchValues.length === 1) {
+      conditions.push('LOWER(c.merchandise) = LOWER(?)');
+      params.push(merchValues[0]);
+    } else if (merchValues.length > 1) {
+      const placeholders = merchValues.map(() => '?').join(',');
+      conditions.push(`LOWER(c.merchandise) IN (${placeholders})`);
+      params.push(...merchValues.map((value) => value.toLowerCase()));
+    }
+  }
+
+  if (filters.issue === 'reported') {
+    conditions.push('(c.status = ? OR c.issue_reported_at IS NOT NULL)');
+    params.push(COURSE_STATUS_ISSUE_REPORTED);
+  } else if (filters.issue === 'none') {
+    conditions.push('(c.status <> ? AND c.issue_reported_at IS NULL)');
+    params.push(COURSE_STATUS_ISSUE_REPORTED);
+  }
+
+  if (filters.hasPhoto !== undefined) {
+    const hasPhoto = parseBoolean(filters.hasPhoto);
+    if (hasPhoto) {
+      conditions.push('c.photo_path IS NOT NULL');
+    } else {
+      conditions.push('c.photo_path IS NULL');
+    }
+  }
+
+  if (filters.hasComments !== undefined) {
+    const hasComments = parseBoolean(filters.hasComments);
+    if (hasComments) {
+      conditions.push("(c.comments IS NOT NULL AND TRIM(c.comments) <> '')");
+    } else {
+      conditions.push("(c.comments IS NULL OR TRIM(c.comments) = '')");
+    }
+  }
+
+  if (filters.search) {
+    const term = `%${String(filters.search).trim().toLowerCase()}%`;
+    const searchConditions = [
+      'LOWER(c.departure) LIKE ?',
+      'LOWER(c.destination) LIKE ?',
+      'LOWER(c.merchandise) LIKE ?',
+      'LOWER(c.comments) LIKE ?',
+      'LOWER(d.first_name || " " || d.last_name) LIKE ?',
+    ];
+    conditions.push(`(${searchConditions.join(' OR ')})`);
+    params.push(term, term, term, term, term);
+  }
+
+  let query = `SELECT c.*, d.first_name, d.last_name FROM courses c
+    LEFT JOIN drivers d ON d.id = c.driver_id`;
+
+  if (conditions.length) {
+    query += ' WHERE ' + conditions.join(' AND ');
+  }
+
+  const orderDirection = filters.order === 'desc' ? 'DESC' : 'ASC';
+  query += ` ORDER BY c.date_time ${orderDirection}`;
+
+  return { query, params };
+}
+
+async function fetchCoursesWithFilters(filters = {}, options = {}) {
+  const { query, params } = buildCourseQuery(filters);
+  if (options.single) {
+    return db.get(query, params);
+  }
+  return db.all(query, params);
+}
 
 function generateAdminSessionToken() {
   return crypto.randomBytes(32).toString('hex');
@@ -1817,107 +2025,180 @@ app.delete('/api/drivers/:id/password', async (req, res) => {
 
 app.get('/api/courses', async (req, res) => {
   try {
-    const { driverId, from, to, archived } = req.query;
-    const conditions = [];
-    const params = [];
-
-    if (driverId) {
-      conditions.push('driver_id = ?');
-      params.push(driverId);
-    }
-
-    if (archived === 'true') {
-      conditions.push('archived_at IS NOT NULL');
-    } else if (archived !== 'all') {
-      conditions.push('archived_at IS NULL');
-    }
-
-    if (from) {
-      conditions.push('date_time >= ?');
-      params.push(new Date(from).toISOString());
-    }
-
-    if (to) {
-      conditions.push('date_time <= ?');
-      params.push(new Date(to).toISOString());
-    }
-
-    let query = `SELECT c.*, d.first_name, d.last_name FROM courses c
-      LEFT JOIN drivers d ON d.id = c.driver_id`;
-
-    if (conditions.length) {
-      query += ' WHERE ' + conditions.join(' AND ');
-    }
-
-    query += ' ORDER BY date_time ASC';
-
-    const rows = await db.all(query, params);
-    res.json(
-      rows.map((row) => ({
-        id: row.id,
-        driverId: row.driver_id,
-        driverName:
-          row.first_name && row.last_name
-            ? `${row.first_name} ${row.last_name}`
-            : row.first_name || row.last_name || null,
-        dateTime: row.date_time,
-        departure: row.departure,
-        destination: row.destination,
-        merchandise: row.merchandise,
-        comments: row.comments,
-        status: row.status,
-        issueReportedAt: row.issue_reported_at,
-        issueReportComment: row.issue_report_comment,
-        issueReportedBy: row.issue_reported_by,
-        photoUrl: row.photo_path ? `/storage/attachments/${path.basename(row.photo_path)}` : null,
-        completionComments: row.completion_comments,
-        archivedAt: row.archived_at,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }))
-    );
+    const rows = await fetchCoursesWithFilters(req.query);
+    res.json(rows.map((row) => mapCourseRow(row)));
   } catch (error) {
     console.error('Error fetching courses', error);
     res.status(500).json({ message: 'Erreur lors de la récupération des courses' });
   }
 });
 
+app.get('/api/courses/export', async (req, res) => {
+  try {
+    const { format: requestedFormat, ...rawFilters } = req.query;
+    const format = (requestedFormat || 'pdf').toString().toLowerCase();
+
+    if (!['pdf', 'xlsx'].includes(format)) {
+      return res.status(400).json({ message: "Format d'export non supporté." });
+    }
+
+    const filters = { ...rawFilters, order: 'asc' };
+    const rows = await fetchCoursesWithFilters(filters);
+    const courses = rows.map((row) => mapCourseRow(row, { includePhotoPath: true }));
+
+    if (!courses.length) {
+      return res.status(404).json({ message: 'Aucune course trouvée pour les filtres sélectionnés.' });
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const baseName = `export-courses-${timestamp}`;
+
+    if (format === 'pdf') {
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="${baseName}.pdf"`);
+
+      const doc = new PDFDocument({ margin: 40, size: 'A4' });
+      doc.pipe(res);
+
+      doc.fontSize(18).text('Export des courses filtrées', { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(12).text(`Total des courses : ${courses.length}`);
+      doc.moveDown();
+
+      courses.forEach((course, index) => {
+        doc.fontSize(14).fillColor('#111111').text(`Course #${course.id}`, { continued: false });
+        doc.moveDown(0.2);
+        doc.fontSize(11).fillColor('#333333');
+        doc.text(`Chauffeur : ${course.driverName || '—'}`);
+        const courseDate = new Date(course.dateTime);
+        doc.text(
+          `Date : ${courseDate.toLocaleDateString('fr-FR')} ${courseDate.toLocaleTimeString('fr-FR', {
+            hour: '2-digit',
+            minute: '2-digit',
+          })}`
+        );
+        doc.text(`Trajet : ${course.departure || '—'} → ${course.destination || '—'}`);
+        doc.text(`Marchandise : ${course.merchandise || '—'}`);
+        doc.text(`Statut : ${course.status || '—'}`);
+        if (course.comments) {
+          doc.text(`Commentaire : ${course.comments}`);
+        }
+        if (course.completionComments) {
+          doc.text(`Commentaire de clôture : ${course.completionComments}`);
+        }
+        if (course.issueReportComment) {
+          doc.text(`Problème signalé : ${course.issueReportComment}`);
+        }
+
+        if (course.photoPath && fs.existsSync(course.photoPath)) {
+          try {
+            doc.moveDown(0.3);
+            doc.text('Photo du bon de livraison :');
+            doc.moveDown(0.3);
+            doc.image(course.photoPath, {
+              fit: [430, 320],
+              align: 'left',
+            });
+          } catch (error) {
+            console.warn(`Impossible d\'ajouter la photo pour la course ${course.id}`, error.message);
+            doc.text('Photo indisponible (erreur de lecture).');
+          }
+        }
+
+        if (index < courses.length - 1) {
+          doc.moveDown();
+          doc.addPage();
+        }
+      });
+
+      doc.end();
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="${baseName}.xlsx"`);
+
+    const workbook = new ExcelJS.Workbook();
+    workbook.creator = 'Agri Holann';
+    workbook.created = new Date();
+    const worksheet = workbook.addWorksheet('Courses');
+
+    worksheet.columns = [
+      { header: 'ID', key: 'id', width: 10 },
+      { header: 'Chauffeur', key: 'driverName', width: 25 },
+      { header: 'Date', key: 'date', width: 15 },
+      { header: 'Heure', key: 'time', width: 10 },
+      { header: 'Départ', key: 'departure', width: 20 },
+      { header: 'Destination', key: 'destination', width: 20 },
+      { header: 'Marchandise', key: 'merchandise', width: 20 },
+      { header: 'Statut', key: 'status', width: 16 },
+      { header: 'Commentaire', key: 'comments', width: 30 },
+      { header: 'Clôture', key: 'completionComments', width: 30 },
+      { header: 'Problème signalé', key: 'issueReportComment', width: 30 },
+      { header: 'Photo', key: 'photo', width: 18 },
+    ];
+
+    for (const course of courses) {
+      const date = new Date(course.dateTime);
+      const row = worksheet.addRow({
+        id: course.id,
+        driverName: course.driverName || '—',
+        date: date.toLocaleDateString('fr-FR'),
+        time: date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' }),
+        departure: course.departure || '—',
+        destination: course.destination || '—',
+        merchandise: course.merchandise || '—',
+        status: course.status || '—',
+        comments: course.comments || '',
+        completionComments: course.completionComments || '',
+        issueReportComment: course.issueReportComment || '',
+      });
+
+      row.alignment = { vertical: 'top', wrapText: true };
+
+      if (course.photoPath && fs.existsSync(course.photoPath)) {
+        try {
+          const imageBuffer = await fs.promises.readFile(course.photoPath);
+          const extension = path.extname(course.photoPath).replace('.', '').toLowerCase() || 'jpg';
+          const imageId = workbook.addImage({
+            buffer: imageBuffer,
+            extension,
+          });
+
+          const rowIndex = row.number - 1; // zero-based for ExcelJS image positioning
+          worksheet.addImage(imageId, {
+            tl: { col: 11, row: rowIndex },
+            ext: { width: 160, height: 120 },
+            editAs: 'oneCell',
+          });
+          row.height = Math.max(row.height || 20, 95);
+        } catch (error) {
+          console.warn(`Impossible d\'embarquer la photo pour la course ${course.id}`, error.message);
+        }
+      }
+    }
+
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (error) {
+    console.error("Erreur lors de la génération de l'export", error);
+    if (!res.headersSent) {
+      res.status(500).json({ message: "Erreur lors de la génération de l'export" });
+    } else {
+      res.end();
+    }
+  }
+});
+
 app.get('/api/courses/:id', async (req, res) => {
   try {
-    const row = await db.get(
-      `SELECT c.*, d.first_name, d.last_name
-       FROM courses c
-       LEFT JOIN drivers d ON d.id = c.driver_id
-       WHERE c.id = ?`,
-      [req.params.id]
-    );
+    const row = await fetchCoursesWithFilters({ id: req.params.id }, { single: true });
 
     if (!row) {
       return res.status(404).json({ message: 'Course introuvable' });
     }
 
-    res.json({
-      id: row.id,
-      driverId: row.driver_id,
-      driverName:
-        row.first_name && row.last_name
-          ? `${row.first_name} ${row.last_name}`
-          : row.first_name || row.last_name || null,
-      dateTime: row.date_time,
-      departure: row.departure,
-      destination: row.destination,
-      merchandise: row.merchandise,
-      comments: row.comments,
-      status: row.status,
-      issueReportedAt: row.issue_reported_at,
-      issueReportComment: row.issue_report_comment,
-      issueReportedBy: row.issue_reported_by,
-      photoUrl: row.photo_path ? `/storage/attachments/${path.basename(row.photo_path)}` : null,
-      completionComments: row.completion_comments,
-      archivedAt: row.archived_at,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    });
+    res.json(mapCourseRow(row));
   } catch (error) {
     console.error('Error fetching course', error);
     res.status(500).json({ message: 'Erreur lors de la récupération de la course' });

--- a/server.js
+++ b/server.js
@@ -94,6 +94,7 @@ const EMAIL_RECIPIENT_SETTING_KEY = 'completion_email_recipient';
 const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
 
 const activeAdminSessions = new Map();
+const sseClients = new Set();
 
 function generateAdminSessionToken() {
   return crypto.randomBytes(32).toString('hex');
@@ -106,6 +107,34 @@ function createAdminSession(admin) {
     expiresAt: Date.now() + ADMIN_SESSION_TTL_MS,
   });
   return token;
+}
+
+function sendSseEvent(client, payload) {
+  try {
+    client.res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  } catch (error) {
+    console.warn('Unable to deliver SSE payload, removing client.', error.message);
+    if (client.heartbeat) {
+      clearInterval(client.heartbeat);
+    }
+    sseClients.delete(client);
+  }
+}
+
+function broadcastEvent(type, payload = {}) {
+  if (!sseClients.size) {
+    return;
+  }
+
+  const message = {
+    type,
+    payload,
+    timestamp: Date.now(),
+  };
+
+  for (const client of Array.from(sseClients)) {
+    sendSseEvent(client, message);
+  }
 }
 
 async function enforceAdminSession(req, res, options = {}) {
@@ -754,6 +783,7 @@ async function logActivity(courseId, action, user, details = null) {
     'INSERT INTO activity_log (course_id, action, user, details, timestamp) VALUES (?, ?, ?, ?, ?)',
     [courseId || null, action, user, normalizeActivityDetails(details), timestamp]
   );
+  broadcastEvent('activity:changed', { action, courseId: courseId || null });
 }
 
 async function mergeCreationAndCompletionActivity(courseId, completionUser, completionDetails = null) {
@@ -886,6 +916,37 @@ app.use(express.json({ limit: '25mb' }));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname)));
 
+app.get('/api/events', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  if (typeof res.flushHeaders === 'function') {
+    res.flushHeaders();
+  }
+
+  res.write('retry: 3000\n\n');
+
+  const client = {
+    res,
+    heartbeat: setInterval(() => {
+      try {
+        res.write(': heartbeat\n\n');
+      } catch (error) {
+        clearInterval(client.heartbeat);
+        sseClients.delete(client);
+      }
+    }, 30000),
+  };
+
+  sseClients.add(client);
+  sendSseEvent(client, { type: 'connection', timestamp: Date.now() });
+
+  req.on('close', () => {
+    clearInterval(client.heartbeat);
+    sseClients.delete(client);
+  });
+});
+
 app.get('/api/drivers', async (req, res) => {
   try {
     const { search } = req.query;
@@ -931,6 +992,7 @@ app.post('/api/drivers', async (req, res) => {
 
     const driver = await db.get('SELECT id, first_name, last_name, email, phone FROM drivers WHERE id = ?', [result.lastID]);
     res.status(201).json(driver);
+    broadcastEvent('drivers:updated', { action: 'created', driverId: driver.id });
   } catch (error) {
     console.error('Error creating driver', error);
     res.status(500).json({ message: 'Erreur lors de la création du chauffeur' });
@@ -955,6 +1017,7 @@ app.delete('/api/drivers/:id', async (req, res) => {
 
     await db.run('DELETE FROM drivers WHERE id = ?', [driverId]);
     res.status(204).send();
+    broadcastEvent('drivers:updated', { action: 'deleted', driverId: Number(driverId) });
   } catch (error) {
     console.error('Error deleting driver', error);
     res.status(500).json({ message: 'Erreur lors de la suppression du chauffeur' });
@@ -1036,6 +1099,7 @@ app.post('/api/admins', async (req, res) => {
       createdAt: admin.created_at,
       role: admin.role,
     });
+    broadcastEvent('admins:updated', { action: 'created', adminId: admin.id });
   } catch (error) {
     console.error('Error creating admin', error);
     res.status(500).json({ message: "Erreur lors de la création du compte administrateur" });
@@ -1065,6 +1129,7 @@ app.delete('/api/admins/:id', async (req, res) => {
 
     await db.run('DELETE FROM admins WHERE id = ?', [adminId]);
     res.status(204).send();
+    broadcastEvent('admins:updated', { action: 'deleted', adminId });
   } catch (error) {
     console.error('Error deleting admin', error);
     res.status(500).json({ message: "Erreur lors de la suppression du compte administrateur" });
@@ -1195,6 +1260,7 @@ app.get('/api/settings/email-recipient', async (req, res) => {
 
     const settings = await getEmailSettingsFromDatabase();
     res.json({ email: settings.recipient });
+    broadcastEvent('settings:email-updated', {});
   } catch (error) {
     console.error('Error fetching email recipient setting', error);
     res
@@ -1339,6 +1405,29 @@ app.get('/api/drivers/:id', async (req, res) => {
   }
 });
 
+app.get('/api/admins/session', async (req, res) => {
+  try {
+    const sessionInfo = await enforceAdminSession(req, res);
+    if (!sessionInfo) {
+      return;
+    }
+
+    const { admin, token } = sessionInfo;
+    res.json({
+      id: admin.id,
+      firstName: admin.first_name,
+      lastName: admin.last_name,
+      identifier: admin.identifier,
+      initials: admin.initials,
+      role: admin.role,
+      token,
+    });
+  } catch (error) {
+    console.error('Error validating admin session', error);
+    res.status(500).json({ message: 'Erreur lors de la validation de la session administrateur' });
+  }
+});
+
 app.post('/api/drivers/login', async (req, res) => {
   try {
     const { driverId, password } = req.body || {};
@@ -1412,6 +1501,7 @@ app.put('/api/drivers/:id/password', async (req, res) => {
     await db.run('UPDATE drivers SET password_hash = ? WHERE id = ?', [passwordHash, driverId]);
 
     res.json({ id: driverId, hasPassword: true });
+    broadcastEvent('driver-passwords:updated', { driverId, hasPassword: true });
   } catch (error) {
     console.error('Error setting driver password', error);
     res.status(500).json({ message: 'Erreur lors de la mise à jour du mot de passe chauffeur' });
@@ -1439,6 +1529,7 @@ app.delete('/api/drivers/:id/password', async (req, res) => {
 
     await db.run('UPDATE drivers SET password_hash = NULL WHERE id = ?', [driverId]);
     res.status(204).send();
+    broadcastEvent('driver-passwords:updated', { driverId, hasPassword: false });
   } catch (error) {
     console.error('Error removing driver password', error);
     res.status(500).json({ message: 'Erreur lors de la suppression du mot de passe chauffeur' });
@@ -1579,6 +1670,11 @@ app.post('/api/courses', async (req, res) => {
     await logActivity(course.id, 'created', creator, { createdBy: creator });
 
     res.status(201).json(course);
+    broadcastEvent('courses:changed', {
+      action: 'created',
+      courseId: course.id,
+      driverId: course.driver_id,
+    });
   } catch (error) {
     console.error('Error creating course', error);
     res.status(500).json({ message: 'Erreur lors de la création de la course' });
@@ -1625,6 +1721,11 @@ app.put('/api/courses/:id', async (req, res) => {
 
     const updated = await db.get('SELECT * FROM courses WHERE id = ?', [courseId]);
     res.json(updated);
+    broadcastEvent('courses:changed', {
+      action: 'updated',
+      courseId: updated.id,
+      driverId: updated.driver_id,
+    });
   } catch (error) {
     console.error('Error updating course', error);
     res.status(500).json({ message: 'Erreur lors de la mise à jour de la course' });
@@ -1651,6 +1752,11 @@ app.delete('/api/courses/:id', async (req, res) => {
     await db.run('DELETE FROM courses WHERE id = ?', [courseId]);
 
     res.status(204).send();
+    broadcastEvent('courses:changed', {
+      action: 'deleted',
+      courseId: Number(courseId),
+      driverId: existing.driver_id,
+    });
   } catch (error) {
     console.error('Error deleting course', error);
     res.status(500).json({ message: 'Erreur lors de la suppression de la course' });
@@ -1672,6 +1778,11 @@ app.post('/api/courses/:id/archive', async (req, res) => {
     await logActivity(courseId, 'archived', user || 'LS', 'Course archivée');
 
     res.json({ message: 'Course archivée', archivedAt });
+    broadcastEvent('courses:changed', {
+      action: 'archived',
+      courseId: Number(courseId),
+      driverId: course.driver_id,
+    });
   } catch (error) {
     console.error('Error archiving course', error);
     res.status(500).json({ message: "Erreur lors de l'archivage de la course" });
@@ -1697,6 +1808,11 @@ app.post('/api/courses/:id/unarchive', async (req, res) => {
     await logActivity(courseId, 'restored', user || 'LS', 'Course désarchivée');
 
     res.json({ message: 'Course restaurée' });
+    broadcastEvent('courses:changed', {
+      action: 'restored',
+      courseId: Number(courseId),
+      driverId: course.driver_id,
+    });
   } catch (error) {
     console.error('Error unarchiving course', error);
     res.status(500).json({ message: 'Erreur lors de la restauration de la course' });
@@ -1739,6 +1855,11 @@ app.post('/api/courses/:id/complete', async (req, res) => {
     );
 
     res.json({ message: 'Course complétée', email: completionEmail });
+    broadcastEvent('courses:changed', {
+      action: 'completed',
+      courseId: Number(courseId),
+      driverId: course.driver_id,
+    });
   } catch (error) {
     console.error('Error completing course', error);
     res

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const crypto = require('crypto');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const DB_PATH = path.join(__dirname, 'db', 'agriholann.db');
+const MESSAGES_DB_PATH = path.join(__dirname, 'db', 'agriholann-messages.db');
 const ATTACHMENTS_DIR = path.join(__dirname, 'storage', 'attachments');
 const FALLBACK_ADMIN_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'admin';
 const SUPER_ADMIN_DEFAULT_PASSWORD = process.env.SUPER_ADMIN_DEFAULT_PASSWORD || 'lannion';
@@ -92,6 +93,10 @@ function loadGmailConfig() {
 }
 const EMAIL_RECIPIENT_SETTING_KEY = 'completion_email_recipient';
 const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
+
+const COURSE_STATUS_PENDING = 'pending';
+const COURSE_STATUS_COMPLETED = 'completed';
+const COURSE_STATUS_ISSUE_REPORTED = 'issue_reported';
 
 const activeAdminSessions = new Map();
 const sseClients = new Set();
@@ -207,6 +212,7 @@ async function ensureDirectoryExists(dirPath) {
 }
 
 let db;
+let messagesDb;
 
 let gmailService = null;
 let gmailConfigSignature = null;
@@ -558,8 +564,120 @@ async function ensureSuperAdmin() {
   }
 }
 
+async function ensureMessagesDatabase() {
+  await ensureDirectoryExists(path.dirname(MESSAGES_DB_PATH));
+
+  messagesDb = await open({
+    filename: MESSAGES_DB_PATH,
+    driver: sqlite3.Database,
+  });
+
+  await messagesDb.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      driver_id INTEGER NOT NULL,
+      sender_type TEXT NOT NULL CHECK(sender_type IN ('driver','admin')),
+      sender_id INTEGER,
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      admin_read_at TEXT,
+      driver_read_at TEXT
+    );
+  `);
+}
+
+function buildPersonInitials(firstName, lastName) {
+  const firstInitial = firstName ? firstName.trim().charAt(0) : '';
+  const lastInitial = lastName ? lastName.trim().charAt(0) : '';
+  const initials = `${firstInitial}${lastInitial}`.toUpperCase();
+  return initials || 'LS';
+}
+
 async function ensureDefaultEmailRecipient() {
   await ensureSetting(EMAIL_RECIPIENT_SETTING_KEY, DEFAULT_COMPLETION_EMAIL);
+}
+
+async function getDriverSummary(driverId) {
+  if (!Number.isInteger(driverId)) {
+    return null;
+  }
+  return db.get(
+    `SELECT id, first_name, last_name, email FROM drivers WHERE id = ?`,
+    [driverId]
+  );
+}
+
+async function getAdminSummary(adminId) {
+  if (!Number.isInteger(adminId)) {
+    return null;
+  }
+  return db.get(
+    `SELECT id, first_name, last_name, identifier FROM admins WHERE id = ?`,
+    [adminId]
+  );
+}
+
+function normalizeMessageBody(body) {
+  if (typeof body !== 'string') {
+    return '';
+  }
+  return body.trim();
+}
+
+async function serializeMessage(row) {
+  if (!row) {
+    return null;
+  }
+
+  const base = {
+    id: row.id,
+    driverId: row.driver_id,
+    senderType: row.sender_type,
+    senderId: row.sender_id,
+    body: row.body,
+    createdAt: row.created_at,
+    adminReadAt: row.admin_read_at || null,
+    driverReadAt: row.driver_read_at || null,
+  };
+
+  if (row.sender_type === 'driver') {
+    const driver = await getDriverSummary(row.driver_id);
+    const firstName = driver?.first_name || '';
+    const lastName = driver?.last_name || '';
+    base.senderLabel = `${firstName} ${lastName}`.trim() || 'Chauffeur';
+    base.senderInitials = buildPersonInitials(firstName, lastName);
+  } else if (row.sender_type === 'admin') {
+    const admin = await getAdminSummary(row.sender_id ?? 0);
+    const firstName = admin?.first_name || '';
+    const lastName = admin?.last_name || '';
+    base.senderLabel = admin ? `${firstName} ${lastName}`.trim() || admin.identifier || 'Admin' : 'Admin';
+    base.senderInitials = buildPersonInitials(firstName, lastName);
+  } else {
+    base.senderLabel = 'Système';
+    base.senderInitials = 'SYS';
+  }
+
+  return base;
+}
+
+async function markMessagesAsRead(driverId, readerType) {
+  if (!messagesDb) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+
+  if (readerType === 'admin') {
+    await messagesDb.run(
+      `UPDATE messages SET admin_read_at = ? WHERE driver_id = ? AND sender_type = 'driver' AND admin_read_at IS NULL`,
+      [now, driverId]
+    );
+  } else if (readerType === 'driver') {
+    await messagesDb.run(
+      `UPDATE messages SET driver_read_at = ? WHERE driver_id = ? AND sender_type = 'admin' AND driver_read_at IS NULL`,
+      [now, driverId]
+    );
+  }
 }
 
 async function initDatabase() {
@@ -572,6 +690,12 @@ async function initDatabase() {
   });
 
   await db.exec('PRAGMA foreign_keys = ON');
+
+  await ensureMessagesDatabase();
+
+  if (messagesDb) {
+    await messagesDb.exec('PRAGMA foreign_keys = ON');
+  }
 
   await db.exec(`
     CREATE TABLE IF NOT EXISTS drivers (
@@ -592,6 +716,9 @@ async function initDatabase() {
       merchandise TEXT,
       comments TEXT,
       status TEXT NOT NULL DEFAULT 'pending',
+      issue_reported_at TEXT,
+      issue_report_comment TEXT,
+      issue_reported_by INTEGER,
       photo_path TEXT,
       completion_comments TEXT,
       archived_at TEXT,
@@ -639,6 +766,9 @@ async function initDatabase() {
   `);
 
   await ensureColumn('courses', 'archived_at', 'TEXT');
+  await ensureColumn('courses', 'issue_reported_at', 'TEXT');
+  await ensureColumn('courses', 'issue_report_comment', 'TEXT');
+  await ensureColumn('courses', 'issue_reported_by', 'INTEGER');
   await ensureColumn('admins', 'password_hash', 'TEXT');
   await ensureColumn("admins", 'role', "TEXT NOT NULL DEFAULT 'standard'");
   await ensureColumn('drivers', 'password_hash', 'TEXT');
@@ -907,6 +1037,36 @@ async function sendCompletionEmail(course, driver, completionComments, photoData
   });
 
   await recordEmail(course.id, to, subject, body, attachmentBuffer, attachmentName);
+
+  return { to, subject, body, messageId: response?.id || null };
+}
+
+async function sendCourseIssueEmail(course, driver, issueComment) {
+  const to = await getCompletionEmailRecipient();
+
+  if (!to) {
+    throw new Error('Aucun destinataire configuré pour les notifications de problème.');
+  }
+
+  const driverFirstName = driver?.first_name || driver?.firstName || '';
+  const driverLastName = driver?.last_name || driver?.lastName || '';
+  const driverLabel = `${driverFirstName} ${driverLastName}`.trim() || 'Chauffeur';
+  const departure = course.departure || 'Lieu de départ non renseigné';
+  const destination = course.destination || 'Destination non renseignée';
+  const dateTime = course.date_time || course.dateTime || new Date().toISOString();
+  const dateLabel = new Date(dateTime).toLocaleString('fr-FR');
+  const comment = issueComment && issueComment.trim() ? issueComment.trim() : 'Aucun détail fourni';
+
+  const subject = `[Incident] ${driverLabel} – ${destination}`;
+  const body = `Le chauffeur ${driverLabel} a signalé un problème sur la course prévue le ${dateLabel}.\n\nTrajet : ${departure} → ${destination}\nCommentaire : ${comment}`;
+
+  const response = await sendGmailMessage({
+    to,
+    subject,
+    text: body,
+  });
+
+  await recordEmail(course.id, to, subject, body, null, EMAIL_ATTACHMENT_NAME);
 
   return { to, subject, body, messageId: response?.id || null };
 }
@@ -1706,6 +1866,9 @@ app.get('/api/courses', async (req, res) => {
         merchandise: row.merchandise,
         comments: row.comments,
         status: row.status,
+        issueReportedAt: row.issue_reported_at,
+        issueReportComment: row.issue_report_comment,
+        issueReportedBy: row.issue_reported_by,
         photoUrl: row.photo_path ? `/storage/attachments/${path.basename(row.photo_path)}` : null,
         completionComments: row.completion_comments,
         archivedAt: row.archived_at,
@@ -1746,6 +1909,9 @@ app.get('/api/courses/:id', async (req, res) => {
       merchandise: row.merchandise,
       comments: row.comments,
       status: row.status,
+      issueReportedAt: row.issue_reported_at,
+      issueReportComment: row.issue_report_comment,
+      issueReportedBy: row.issue_reported_by,
       photoUrl: row.photo_path ? `/storage/attachments/${path.basename(row.photo_path)}` : null,
       completionComments: row.completion_comments,
       archivedAt: row.archived_at,
@@ -1938,6 +2104,82 @@ app.post('/api/courses/:id/unarchive', async (req, res) => {
   }
 });
 
+app.post('/api/courses/:id/report-issue', async (req, res) => {
+  try {
+    const courseId = Number.parseInt(req.params.id, 10);
+    if (!Number.isInteger(courseId)) {
+      return res.status(400).json({ message: 'Identifiant de course invalide.' });
+    }
+
+    const { driverId, comment } = req.body || {};
+    const normalizedComment = typeof comment === 'string' ? comment.trim() : '';
+
+    if (!driverId || !Number.isInteger(Number(driverId))) {
+      return res.status(400).json({ message: 'Chauffeur requis pour signaler un problème.' });
+    }
+
+    const course = await db.get('SELECT * FROM courses WHERE id = ?', [courseId]);
+    if (!course) {
+      return res.status(404).json({ message: 'Course introuvable.' });
+    }
+
+    if (course.driver_id !== Number(driverId)) {
+      return res.status(403).json({ message: 'Ce chauffeur ne peut pas signaler cette course.' });
+    }
+
+    if (course.status === COURSE_STATUS_COMPLETED) {
+      return res.status(400).json({ message: 'Impossible de signaler une course déjà validée.' });
+    }
+
+    const driver = await getDriverSummary(course.driver_id);
+    if (!driver) {
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
+    }
+
+    const updatedAt = new Date().toISOString();
+
+    await db.run(
+      `UPDATE courses
+          SET status = ?,
+              issue_reported_at = ?,
+              issue_report_comment = ?,
+              issue_reported_by = ?,
+              updated_at = ?
+        WHERE id = ?`,
+      [
+        COURSE_STATUS_ISSUE_REPORTED,
+        updatedAt,
+        normalizedComment || null,
+        course.driver_id,
+        updatedAt,
+        courseId,
+      ]
+    );
+
+    const initials = buildPersonInitials(driver.first_name, driver.last_name);
+    await logActivity(courseId, 'issue_reported', initials, {
+      comment: normalizedComment || undefined,
+    });
+
+    let emailResult = null;
+    try {
+      emailResult = await sendCourseIssueEmail(course, driver, normalizedComment);
+    } catch (emailError) {
+      console.error("Erreur lors de l'envoi de la notification de problème", emailError);
+    }
+
+    res.json({ message: 'Problème signalé', email: emailResult });
+    broadcastEvent('courses:changed', {
+      action: 'issue_reported',
+      courseId,
+      driverId: course.driver_id,
+    });
+  } catch (error) {
+    console.error('Error reporting course issue', error);
+    res.status(500).json({ message: "Erreur lors du signalement du problème" });
+  }
+});
+
 app.post('/api/courses/:id/complete', async (req, res) => {
   try {
     const courseId = req.params.id;
@@ -1984,6 +2226,306 @@ app.post('/api/courses/:id/complete', async (req, res) => {
     res
       .status(500)
       .json({ message: error.message || 'Erreur lors de la validation de la course' });
+  }
+});
+
+app.get('/api/messages/unread-count', async (req, res) => {
+  try {
+    if (!messagesDb) {
+      throw new Error('Base de données des messages indisponible');
+    }
+
+    const role = (req.query.role || '').toLowerCase();
+
+    if (role === 'admin') {
+      const sessionInfo = await enforceAdminSession(req, res, {
+        allowRoles: Array.from(ADMIN_ROLES),
+      });
+      if (!sessionInfo) {
+        return;
+      }
+
+      const totalRow = await messagesDb.get(
+        `SELECT COUNT(*) AS total FROM messages WHERE sender_type = 'driver' AND admin_read_at IS NULL`
+      );
+      const perDriverRows = await messagesDb.all(
+        `SELECT driver_id AS driverId, COUNT(*) AS count
+           FROM messages
+          WHERE sender_type = 'driver' AND admin_read_at IS NULL
+          GROUP BY driver_id`
+      );
+
+      res.json({
+        total: totalRow?.total || 0,
+        perDriver: perDriverRows || [],
+      });
+      return;
+    }
+
+    if (role === 'driver') {
+      const driverId = Number.parseInt(req.query.driverId, 10);
+      if (!Number.isInteger(driverId)) {
+        return res.status(400).json({ message: 'Identifiant chauffeur invalide.' });
+      }
+
+      const driver = await getDriverSummary(driverId);
+      if (!driver) {
+        return res.status(404).json({ message: 'Chauffeur introuvable.' });
+      }
+
+      const row = await messagesDb.get(
+        `SELECT COUNT(*) AS total
+           FROM messages
+          WHERE driver_id = ? AND sender_type = 'admin' AND driver_read_at IS NULL`,
+        [driverId]
+      );
+
+      res.json({ total: row?.total || 0 });
+      return;
+    }
+
+    res.status(400).json({ message: 'Rôle invalide pour la récupération des messages.' });
+  } catch (error) {
+    console.error('Error fetching unread message count', error);
+    res.status(500).json({ message: 'Erreur lors de la récupération du nombre de messages.' });
+  }
+});
+
+app.get('/api/messages/inbox', async (req, res) => {
+  try {
+    if (!messagesDb) {
+      throw new Error('Base de données des messages indisponible');
+    }
+
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const rows = await messagesDb.all(
+      `SELECT * FROM messages ORDER BY datetime(created_at) DESC LIMIT 500`
+    );
+
+    const threads = new Map();
+
+    for (const row of rows) {
+      const thread = threads.get(row.driver_id) || {
+        driverId: row.driver_id,
+        lastMessageAt: row.created_at,
+        lastMessageBody: row.body,
+        lastSenderType: row.sender_type,
+        unreadFromDriver: 0,
+      };
+
+      if (!threads.has(row.driver_id)) {
+        thread.lastMessageAt = row.created_at;
+        thread.lastMessageBody = row.body;
+        thread.lastSenderType = row.sender_type;
+      }
+
+      if (row.sender_type === 'driver' && !row.admin_read_at) {
+        thread.unreadFromDriver += 1;
+      }
+
+      threads.set(row.driver_id, thread);
+    }
+
+    const driverIds = Array.from(threads.keys());
+    const driverSummaries = await Promise.all(driverIds.map((id) => getDriverSummary(id)));
+
+    const payload = driverIds.map((driverId, index) => {
+      const summary = driverSummaries[index];
+      const info = threads.get(driverId);
+      return {
+        driverId,
+        driverName: summary
+          ? `${summary.first_name || ''} ${summary.last_name || ''}`.trim() || 'Chauffeur'
+          : 'Chauffeur',
+        unreadFromDriver: info.unreadFromDriver,
+        lastMessageAt: info.lastMessageAt,
+        lastMessageBody: info.lastMessageBody,
+        lastSenderType: info.lastSenderType,
+      };
+    });
+
+    res.json(payload);
+  } catch (error) {
+    console.error('Error fetching message inbox', error);
+    res.status(500).json({ message: 'Erreur lors de la récupération des conversations.' });
+  }
+});
+
+app.get('/api/messages/threads/:driverId', async (req, res) => {
+  try {
+    if (!messagesDb) {
+      throw new Error('Base de données des messages indisponible');
+    }
+
+    const driverId = Number.parseInt(req.params.driverId, 10);
+    if (!Number.isInteger(driverId)) {
+      return res.status(400).json({ message: 'Identifiant chauffeur invalide.' });
+    }
+
+    const role = (req.query.role || '').toLowerCase();
+
+    if (role === 'admin') {
+      const sessionInfo = await enforceAdminSession(req, res, {
+        allowRoles: Array.from(ADMIN_ROLES),
+      });
+      if (!sessionInfo) {
+        return;
+      }
+    } else {
+      const driverIdQuery = Number.parseInt(req.query.driverId || driverId, 10);
+      if (driverIdQuery !== driverId) {
+        return res.status(403).json({ message: 'Accès refusé.' });
+      }
+    }
+
+    const driver = await getDriverSummary(driverId);
+    if (!driver) {
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
+    }
+
+    const rows = await messagesDb.all(
+      `SELECT * FROM messages WHERE driver_id = ? ORDER BY datetime(created_at) ASC`,
+      [driverId]
+    );
+
+    const messages = await Promise.all(rows.map((row) => serializeMessage(row)));
+
+    const readerType = role === 'admin' ? 'admin' : 'driver';
+    await markMessagesAsRead(driverId, readerType);
+
+    broadcastEvent('messages:read', {
+      driverId,
+      readerType,
+    });
+
+    res.json({
+      driver: {
+        id: driver.id,
+        firstName: driver.first_name,
+        lastName: driver.last_name,
+      },
+      messages,
+    });
+  } catch (error) {
+    console.error('Error fetching message thread', error);
+    res.status(500).json({ message: 'Erreur lors de la récupération de la conversation.' });
+  }
+});
+
+app.post('/api/messages', async (req, res) => {
+  try {
+    if (!messagesDb) {
+      throw new Error('Base de données des messages indisponible');
+    }
+
+    const { driverId, body, senderType } = req.body || {};
+    const normalizedBody = normalizeMessageBody(body);
+
+    if (!driverId || !Number.isInteger(Number(driverId))) {
+      return res.status(400).json({ message: 'Identifiant chauffeur manquant.' });
+    }
+
+    if (!normalizedBody) {
+      return res.status(400).json({ message: 'Le message ne peut pas être vide.' });
+    }
+
+    const driver = await getDriverSummary(Number(driverId));
+    if (!driver) {
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
+    }
+
+    let senderId = null;
+    const now = new Date().toISOString();
+    let adminReadAt = null;
+    let driverReadAt = null;
+
+    if (senderType === 'admin') {
+      const sessionInfo = await enforceAdminSession(req, res, {
+        allowRoles: Array.from(ADMIN_ROLES),
+      });
+      if (!sessionInfo) {
+        return;
+      }
+      senderId = sessionInfo.admin.id;
+      adminReadAt = now;
+    } else if (senderType === 'driver') {
+      if (Number(driverId) !== Number(req.body.driverId)) {
+        return res.status(403).json({ message: 'Accès refusé.' });
+      }
+      driverReadAt = now;
+    } else {
+      return res.status(400).json({ message: "Type d'envoyeur invalide." });
+    }
+
+    const insertResult = await messagesDb.run(
+      `INSERT INTO messages (driver_id, sender_type, sender_id, body, created_at, admin_read_at, driver_read_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [Number(driverId), senderType, senderId, normalizedBody, now, adminReadAt, driverReadAt]
+    );
+
+    const row = await messagesDb.get('SELECT * FROM messages WHERE id = ?', [insertResult.lastID]);
+    const message = await serializeMessage(row);
+
+    broadcastEvent('messages:new', {
+      driverId: Number(driverId),
+      senderType,
+      message,
+    });
+
+    res.status(201).json(message);
+  } catch (error) {
+    console.error('Error creating message', error);
+    res.status(500).json({ message: "Erreur lors de l'envoi du message." });
+  }
+});
+
+app.post('/api/messages/:driverId/read', async (req, res) => {
+  try {
+    if (!messagesDb) {
+      throw new Error('Base de données des messages indisponible');
+    }
+
+    const driverId = Number.parseInt(req.params.driverId, 10);
+    if (!Number.isInteger(driverId)) {
+      return res.status(400).json({ message: 'Identifiant chauffeur invalide.' });
+    }
+
+    const { readerType } = req.body || {};
+    if (!readerType || (readerType !== 'admin' && readerType !== 'driver')) {
+      return res.status(400).json({ message: 'Type de lecteur invalide.' });
+    }
+
+    if (readerType === 'admin') {
+      const sessionInfo = await enforceAdminSession(req, res, {
+        allowRoles: Array.from(ADMIN_ROLES),
+      });
+      if (!sessionInfo) {
+        return;
+      }
+    } else {
+      const driver = await getDriverSummary(driverId);
+      if (!driver) {
+        return res.status(404).json({ message: 'Chauffeur introuvable.' });
+      }
+    }
+
+    await markMessagesAsRead(driverId, readerType);
+
+    broadcastEvent('messages:read', {
+      driverId,
+      readerType,
+    });
+
+    res.json({ message: 'Messages marqués comme lus.' });
+  } catch (error) {
+    console.error('Error marking messages as read', error);
+    res.status(500).json({ message: 'Erreur lors de la mise à jour des messages.' });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -19,6 +19,10 @@ const GMAIL_CONFIG_SOURCES = {
   credentialsPath: process.env.GMAIL_CREDENTIALS_PATH || path.join(__dirname, 'credentials.json'),
   tokenPath: process.env.GMAIL_TOKEN_PATH || path.join(__dirname, 'token.json'),
 };
+const GMAIL_CLIENT_ID_SETTING_KEY = 'gmail_client_id';
+const GMAIL_CLIENT_SECRET_SETTING_KEY = 'gmail_client_secret';
+const GMAIL_REFRESH_TOKEN_SETTING_KEY = 'gmail_refresh_token';
+const GMAIL_REDIRECT_URI_SETTING_KEY = 'gmail_redirect_uri';
 
 function applyFallback(config, key, value) {
   if (!config[key] && typeof value === 'string' && value.trim()) {
@@ -33,6 +37,19 @@ function loadGmailConfig() {
     redirectUri: (process.env.GMAIL_REDIRECT_URI || '').trim(),
     refreshToken: (process.env.GMAIL_REFRESH_TOKEN || '').trim(),
   };
+
+  if (!config.clientId && gmailDbConfig.clientId) {
+    config.clientId = gmailDbConfig.clientId;
+  }
+  if (!config.clientSecret && gmailDbConfig.clientSecret) {
+    config.clientSecret = gmailDbConfig.clientSecret;
+  }
+  if (!config.redirectUri && gmailDbConfig.redirectUri) {
+    config.redirectUri = gmailDbConfig.redirectUri;
+  }
+  if (!config.refreshToken && gmailDbConfig.refreshToken) {
+    config.refreshToken = gmailDbConfig.refreshToken;
+  }
 
   if (fs.existsSync(GMAIL_CONFIG_SOURCES.credentialsPath)) {
     try {
@@ -90,6 +107,12 @@ let db;
 
 let gmailService = null;
 let gmailConfigSignature = null;
+let gmailDbConfig = {
+  clientId: '',
+  clientSecret: '',
+  refreshToken: '',
+  redirectUri: '',
+};
 
 async function columnExists(table, column) {
   const pragma = await db.all(`PRAGMA table_info(${table})`);
@@ -114,6 +137,91 @@ async function ensureSetting(key, defaultValue) {
   if (existing === null || existing === undefined) {
     await setSettingValue(key, defaultValue);
   }
+}
+
+async function refreshGmailSettingsCache() {
+  const [clientId, clientSecret, refreshToken, redirectUri] = await Promise.all([
+    getSetting(GMAIL_CLIENT_ID_SETTING_KEY),
+    getSetting(GMAIL_CLIENT_SECRET_SETTING_KEY),
+    getSetting(GMAIL_REFRESH_TOKEN_SETTING_KEY),
+    getSetting(GMAIL_REDIRECT_URI_SETTING_KEY),
+  ]);
+
+  gmailDbConfig = {
+    clientId: (clientId || '').trim(),
+    clientSecret: (clientSecret || '').trim(),
+    refreshToken: (refreshToken || '').trim(),
+    redirectUri: (redirectUri || '').trim(),
+  };
+
+  return gmailDbConfig;
+}
+
+async function ensureDefaultGmailSettings() {
+  await ensureSetting(GMAIL_CLIENT_ID_SETTING_KEY, (process.env.GMAIL_CLIENT_ID || '').trim());
+  await ensureSetting(GMAIL_CLIENT_SECRET_SETTING_KEY, (process.env.GMAIL_CLIENT_SECRET || '').trim());
+  await ensureSetting(GMAIL_REFRESH_TOKEN_SETTING_KEY, (process.env.GMAIL_REFRESH_TOKEN || '').trim());
+  await ensureSetting(
+    GMAIL_REDIRECT_URI_SETTING_KEY,
+    (process.env.GMAIL_REDIRECT_URI || DEFAULT_GMAIL_REDIRECT_URI).trim()
+  );
+
+  await refreshGmailSettingsCache();
+}
+
+async function getEmailSettingsFromDatabase() {
+  const [recipient, gmailSettings] = await Promise.all([
+    getCompletionEmailRecipient(),
+    refreshGmailSettingsCache(),
+  ]);
+
+  return {
+    recipient,
+    gmailClientId: gmailSettings.clientId,
+    gmailClientSecret: gmailSettings.clientSecret,
+    gmailRefreshToken: gmailSettings.refreshToken,
+    gmailRedirectUri: gmailSettings.redirectUri || DEFAULT_GMAIL_REDIRECT_URI,
+  };
+}
+
+async function persistEmailSettings({
+  recipient,
+  gmailClientId,
+  gmailClientSecret,
+  gmailRefreshToken,
+  gmailRedirectUri,
+}) {
+  const updates = [];
+
+  if (typeof recipient === 'string') {
+    updates.push(setSettingValue(EMAIL_RECIPIENT_SETTING_KEY, recipient.trim()));
+  }
+
+  if (typeof gmailClientId === 'string') {
+    updates.push(setSettingValue(GMAIL_CLIENT_ID_SETTING_KEY, gmailClientId.trim()));
+  }
+
+  if (typeof gmailClientSecret === 'string') {
+    updates.push(setSettingValue(GMAIL_CLIENT_SECRET_SETTING_KEY, gmailClientSecret.trim()));
+  }
+
+  if (typeof gmailRefreshToken === 'string') {
+    updates.push(setSettingValue(GMAIL_REFRESH_TOKEN_SETTING_KEY, gmailRefreshToken.trim()));
+  }
+
+  if (typeof gmailRedirectUri === 'string') {
+    const value = gmailRedirectUri.trim() || DEFAULT_GMAIL_REDIRECT_URI;
+    updates.push(setSettingValue(GMAIL_REDIRECT_URI_SETTING_KEY, value));
+  }
+
+  if (updates.length) {
+    await Promise.all(updates);
+    await refreshGmailSettingsCache();
+    gmailService = null;
+    gmailConfigSignature = null;
+  }
+
+  return getEmailSettingsFromDatabase();
 }
 
 async function getCompletionEmailRecipient() {
@@ -482,6 +590,7 @@ async function initDatabase() {
 
   await ensureDefaultAdmin();
   await ensureDefaultEmailRecipient();
+  await ensureDefaultGmailSettings();
 }
 
 function normalizeActivityDetails(details) {
@@ -778,10 +887,64 @@ app.post('/api/admins', async (req, res) => {
   }
 });
 
+app.get('/api/settings/email-config', async (req, res) => {
+  try {
+    const settings = await getEmailSettingsFromDatabase();
+    res.json(settings);
+  } catch (error) {
+    console.error('Error fetching email configuration', error);
+    res
+      .status(500)
+      .json({ message: "Erreur lors de la récupération de la configuration email" });
+  }
+});
+
+app.put('/api/settings/email-config', async (req, res) => {
+  try {
+    const {
+      recipient,
+      gmailClientId,
+      gmailClientSecret,
+      gmailRefreshToken,
+      gmailRedirectUri,
+    } = req.body || {};
+
+    const normalizedRecipient = typeof recipient === 'string' ? recipient.trim() : '';
+    const normalizedClientId = typeof gmailClientId === 'string' ? gmailClientId.trim() : '';
+    const normalizedClientSecret =
+      typeof gmailClientSecret === 'string' ? gmailClientSecret.trim() : '';
+    const normalizedRefreshToken =
+      typeof gmailRefreshToken === 'string' ? gmailRefreshToken.trim() : '';
+    const normalizedRedirectUri =
+      typeof gmailRedirectUri === 'string' ? gmailRedirectUri.trim() : DEFAULT_GMAIL_REDIRECT_URI;
+
+    if (!isValidEmail(normalizedRecipient)) {
+      return res.status(400).json({ message: 'Adresse email de réception invalide.' });
+    }
+
+    if (!normalizedClientId || !normalizedClientSecret || !normalizedRefreshToken) {
+      return res.status(400).json({ message: 'Veuillez renseigner les identifiants Gmail complets.' });
+    }
+
+    const settings = await persistEmailSettings({
+      recipient: normalizedRecipient,
+      gmailClientId: normalizedClientId,
+      gmailClientSecret: normalizedClientSecret,
+      gmailRefreshToken: normalizedRefreshToken,
+      gmailRedirectUri: normalizedRedirectUri,
+    });
+
+    res.json(settings);
+  } catch (error) {
+    console.error('Error updating email configuration', error);
+    res.status(500).json({ message: "Erreur lors de la mise à jour de la configuration email" });
+  }
+});
+
 app.get('/api/settings/email-recipient', async (req, res) => {
   try {
-    const email = await getCompletionEmailRecipient();
-    res.json({ email });
+    const settings = await getEmailSettingsFromDatabase();
+    res.json({ email: settings.recipient });
   } catch (error) {
     console.error('Error fetching email recipient setting', error);
     res
@@ -792,16 +955,16 @@ app.get('/api/settings/email-recipient', async (req, res) => {
 
 app.put('/api/settings/email-recipient', async (req, res) => {
   try {
-    const { email } = req.body;
+    const { email } = req.body || {};
     const normalizedEmail = typeof email === 'string' ? email.trim() : '';
 
     if (!isValidEmail(normalizedEmail)) {
       return res.status(400).json({ message: 'Adresse email invalide.' });
     }
 
-    await setSettingValue(EMAIL_RECIPIENT_SETTING_KEY, normalizedEmail);
+    const settings = await persistEmailSettings({ recipient: normalizedEmail });
 
-    res.json({ email: normalizedEmail });
+    res.json({ email: settings.recipient });
   } catch (error) {
     console.error('Error updating email recipient setting', error);
     res

--- a/server.js
+++ b/server.js
@@ -13,52 +13,58 @@ const DB_PATH = path.join(__dirname, 'db', 'agriholann.db');
 const ATTACHMENTS_DIR = path.join(__dirname, 'storage', 'attachments');
 const DEFAULT_ADMIN_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'admin';
 const DEFAULT_COMPLETION_EMAIL = process.env.DEFAULT_COMPLETION_EMAIL || 'laurent.saquet@agriholann.com';
+const DEFAULT_GMAIL_REDIRECT_URI = 'http://localhost';
+const GMAIL_SENDER = process.env.GMAIL_SENDER || 'chauffeur.agriholann@gmail.com';
+const GMAIL_CONFIG_SOURCES = {
+  credentialsPath: process.env.GMAIL_CREDENTIALS_PATH || path.join(__dirname, 'credentials.json'),
+  tokenPath: process.env.GMAIL_TOKEN_PATH || path.join(__dirname, 'token.json'),
+};
+
+function applyFallback(config, key, value) {
+  if (!config[key] && typeof value === 'string' && value.trim()) {
+    config[key] = value.trim();
+  }
+}
 
 function loadGmailConfig() {
   const config = {
-    clientId: '',
-    clientSecret: '',
-    redirectUri: '',
-    refreshToken: '',
+    clientId: (process.env.GMAIL_CLIENT_ID || '').trim(),
+    clientSecret: (process.env.GMAIL_CLIENT_SECRET || '').trim(),
+    redirectUri: (process.env.GMAIL_REDIRECT_URI || '').trim(),
+    refreshToken: (process.env.GMAIL_REFRESH_TOKEN || '').trim(),
   };
 
-  const credentialsPath = process.env.GMAIL_CREDENTIALS_PATH || path.join(__dirname, 'credentials.json');
-  const tokenPath = process.env.GMAIL_TOKEN_PATH || path.join(__dirname, 'token.json');
-
-  if (fs.existsSync(credentialsPath)) {
+  if (fs.existsSync(GMAIL_CONFIG_SOURCES.credentialsPath)) {
     try {
-      const rawCredentials = JSON.parse(fs.readFileSync(credentialsPath, 'utf8'));
+      const rawCredentials = JSON.parse(fs.readFileSync(GMAIL_CONFIG_SOURCES.credentialsPath, 'utf8'));
       const oauthConfig = rawCredentials.web || rawCredentials.installed || {};
-      config.clientId = oauthConfig.client_id || config.clientId;
-      config.clientSecret = oauthConfig.client_secret || config.clientSecret;
+      applyFallback(config, 'clientId', oauthConfig.client_id);
+      applyFallback(config, 'clientSecret', oauthConfig.client_secret);
       if (Array.isArray(oauthConfig.redirect_uris) && oauthConfig.redirect_uris.length > 0) {
-        config.redirectUri = oauthConfig.redirect_uris[0];
+        applyFallback(config, 'redirectUri', oauthConfig.redirect_uris[0]);
+      } else if (typeof oauthConfig.redirect_uri === 'string') {
+        applyFallback(config, 'redirectUri', oauthConfig.redirect_uri);
       }
     } catch (error) {
       console.error('Impossible de lire credentials.json :', error.message);
     }
   }
 
-  if (fs.existsSync(tokenPath)) {
+  if (fs.existsSync(GMAIL_CONFIG_SOURCES.tokenPath)) {
     try {
-      const token = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
-      config.refreshToken = token.refresh_token || config.refreshToken;
+      const token = JSON.parse(fs.readFileSync(GMAIL_CONFIG_SOURCES.tokenPath, 'utf8'));
+      applyFallback(config, 'refreshToken', token.refresh_token || token.refreshToken);
     } catch (error) {
       console.error('Impossible de lire token.json :', error.message);
     }
   }
 
+  if (!config.redirectUri) {
+    config.redirectUri = DEFAULT_GMAIL_REDIRECT_URI;
+  }
+
   return config;
 }
-
-const gmailFileConfig = loadGmailConfig();
-
-const GMAIL_CLIENT_ID = process.env.GMAIL_CLIENT_ID || gmailFileConfig.clientId || '';
-const GMAIL_CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || gmailFileConfig.clientSecret || '';
-const GMAIL_REDIRECT_URI =
-  process.env.GMAIL_REDIRECT_URI || gmailFileConfig.redirectUri || 'http://localhost';
-const GMAIL_REFRESH_TOKEN = process.env.GMAIL_REFRESH_TOKEN || gmailFileConfig.refreshToken || '';
-const GMAIL_SENDER = process.env.GMAIL_SENDER || 'chauffeur.agriholann@gmail.com';
 const EMAIL_RECIPIENT_SETTING_KEY = 'completion_email_recipient';
 const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
 
@@ -83,6 +89,7 @@ async function ensureDirectoryExists(dirPath) {
 let db;
 
 let gmailService = null;
+let gmailConfigSignature = null;
 
 async function columnExists(table, column) {
   const pragma = await db.all(`PRAGMA table_info(${table})`);
@@ -115,17 +122,23 @@ async function getCompletionEmailRecipient() {
 }
 
 function getGmailService() {
-  if (!GMAIL_CLIENT_ID || !GMAIL_CLIENT_SECRET || !GMAIL_REFRESH_TOKEN) {
-    return null;
+  const config = loadGmailConfig();
+  const signature = JSON.stringify(config);
+
+  if (!config.clientId || !config.clientSecret || !config.refreshToken) {
+    gmailService = null;
+    gmailConfigSignature = null;
+    return { service: null, config };
   }
 
-  if (!gmailService) {
-    const oAuth2Client = new google.auth.OAuth2(GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REDIRECT_URI);
-    oAuth2Client.setCredentials({ refresh_token: GMAIL_REFRESH_TOKEN });
+  if (!gmailService || gmailConfigSignature !== signature) {
+    const oAuth2Client = new google.auth.OAuth2(config.clientId, config.clientSecret, config.redirectUri);
+    oAuth2Client.setCredentials({ refresh_token: config.refreshToken });
     gmailService = google.gmail({ version: 'v1', auth: oAuth2Client });
+    gmailConfigSignature = signature;
   }
 
-  return gmailService;
+  return { service: gmailService, config };
 }
 
 function buildMimeMessage({ from, to, subject, text, attachmentBuffer, attachmentName, attachmentMimeType }) {
@@ -180,11 +193,17 @@ async function sendGmailMessage({
   attachmentName = EMAIL_ATTACHMENT_NAME,
   attachmentMimeType = 'application/octet-stream',
 }) {
-  const service = getGmailService();
+  const { service, config } = getGmailService();
 
   if (!service) {
+    const missing = [];
+    if (!config.clientId) missing.push('client_id');
+    if (!config.clientSecret) missing.push('client_secret');
+    if (!config.refreshToken) missing.push('refresh_token');
+    const missingDetails = missing.length ? ` (éléments manquants : ${missing.join(', ')})` : '';
+    const locationHint = ` Fichiers recherchés : ${GMAIL_CONFIG_SOURCES.credentialsPath}, ${GMAIL_CONFIG_SOURCES.tokenPath}.`;
     throw new Error(
-      'Configuration de la messagerie Gmail manquante. Définissez les variables GMAIL_* ou fournissez credentials.json et token.json.'
+      `Configuration de la messagerie Gmail manquante. Définissez les variables GMAIL_* ou fournissez credentials.json et token.json${missingDetails}.${locationHint}`
     );
   }
 

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const express = require('express');
 const cors = require('cors');
-const nodemailer = require('nodemailer');
+const { google } = require('googleapis');
 const sqlite3 = require('sqlite3').verbose();
 const { open } = require('sqlite');
 const bcrypt = require('bcryptjs');
@@ -12,6 +12,14 @@ const PORT = process.env.PORT || 3000;
 const DB_PATH = path.join(__dirname, 'db', 'agriholann.db');
 const ATTACHMENTS_DIR = path.join(__dirname, 'storage', 'attachments');
 const DEFAULT_ADMIN_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'admin';
+const DEFAULT_COMPLETION_EMAIL = process.env.DEFAULT_COMPLETION_EMAIL || 'laurent.saquet@agriholann.com';
+const GMAIL_CLIENT_ID = process.env.GMAIL_CLIENT_ID || '';
+const GMAIL_CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || '';
+const GMAIL_REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || 'http://localhost';
+const GMAIL_REFRESH_TOKEN = process.env.GMAIL_REFRESH_TOKEN || '';
+const GMAIL_SENDER = process.env.GMAIL_SENDER || 'chauffeur.agriholann@gmail.com';
+const EMAIL_RECIPIENT_SETTING_KEY = 'completion_email_recipient';
+const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
 
 async function hashPassword(password) {
   const value = password || '';
@@ -33,9 +41,134 @@ async function ensureDirectoryExists(dirPath) {
 
 let db;
 
+let gmailService = null;
+
 async function columnExists(table, column) {
   const pragma = await db.all(`PRAGMA table_info(${table})`);
   return pragma.some((entry) => entry.name === column);
+}
+
+async function getSetting(key) {
+  const row = await db.get('SELECT value FROM settings WHERE key = ?', [key]);
+  return row ? row.value : null;
+}
+
+async function setSettingValue(key, value) {
+  await db.run(
+    `INSERT INTO settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    [key, value]
+  );
+}
+
+async function ensureSetting(key, defaultValue) {
+  const existing = await getSetting(key);
+  if (existing === null || existing === undefined) {
+    await setSettingValue(key, defaultValue);
+  }
+}
+
+async function getCompletionEmailRecipient() {
+  const recipient = await getSetting(EMAIL_RECIPIENT_SETTING_KEY);
+  return recipient || DEFAULT_COMPLETION_EMAIL;
+}
+
+function getGmailService() {
+  if (!GMAIL_CLIENT_ID || !GMAIL_CLIENT_SECRET || !GMAIL_REFRESH_TOKEN) {
+    return null;
+  }
+
+  if (!gmailService) {
+    const oAuth2Client = new google.auth.OAuth2(GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REDIRECT_URI);
+    oAuth2Client.setCredentials({ refresh_token: GMAIL_REFRESH_TOKEN });
+    gmailService = google.gmail({ version: 'v1', auth: oAuth2Client });
+  }
+
+  return gmailService;
+}
+
+function buildMimeMessage({ from, to, subject, text, attachmentBuffer, attachmentName, attachmentMimeType }) {
+  if (attachmentBuffer) {
+    const boundary = `===============${Date.now()}==`;
+    const base64Attachment = attachmentBuffer
+      .toString('base64')
+      .replace(/(.{76})/g, '$1\n');
+
+    return [
+      `From: ${from}`,
+      `To: ${to}`,
+      `Subject: ${subject}`,
+      'MIME-Version: 1.0',
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+      '',
+      `--${boundary}`,
+      'Content-Type: text/plain; charset="UTF-8"',
+      'Content-Transfer-Encoding: 7bit',
+      '',
+      text,
+      '',
+      `--${boundary}`,
+      `Content-Type: ${attachmentMimeType || 'application/octet-stream'}; name="${attachmentName}"`,
+      'Content-Transfer-Encoding: base64',
+      `Content-Disposition: attachment; filename="${attachmentName}"`,
+      '',
+      base64Attachment,
+      '',
+      `--${boundary}--`,
+      '',
+    ].join('\n');
+  }
+
+  return [
+    `From: ${from}`,
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset="UTF-8"',
+    'Content-Transfer-Encoding: 7bit',
+    '',
+    text,
+  ].join('\n');
+}
+
+async function sendGmailMessage({
+  to,
+  subject,
+  text,
+  attachmentBuffer = null,
+  attachmentName = EMAIL_ATTACHMENT_NAME,
+  attachmentMimeType = 'application/octet-stream',
+}) {
+  const service = getGmailService();
+
+  if (!service) {
+    throw new Error('Configuration de la messagerie Gmail manquante. Veuillez vérifier les identifiants OAuth.');
+  }
+
+  const rawMessage = buildMimeMessage({
+    from: GMAIL_SENDER,
+    to,
+    subject,
+    text,
+    attachmentBuffer,
+    attachmentName,
+    attachmentMimeType,
+  });
+
+  const encodedMessage = Buffer.from(rawMessage)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+  const response = await service.users.messages.send({
+    userId: 'me',
+    requestBody: {
+      raw: encodedMessage,
+    },
+  });
+
+  return response.data;
 }
 
 async function ensureColumn(table, column, definition) {
@@ -58,6 +191,13 @@ function buildAdminInitials(firstName, lastName) {
   const lastInitial = lastName ? lastName.trim().charAt(0) : '';
   const initials = `${firstInitial}${lastInitial}`.toUpperCase();
   return initials || 'AA';
+}
+
+function isValidEmail(email) {
+  if (!email) {
+    return false;
+  }
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
 async function generateUniqueAdminIdentifier(firstName, lastName) {
@@ -97,6 +237,10 @@ async function ensureDefaultAdmin() {
      VALUES (?, ?, ?, ?, ?, ?)`,
     [firstName, lastName, identifier, initials, createdAt, passwordHash]
   );
+}
+
+async function ensureDefaultEmailRecipient() {
+  await ensureSetting(EMAIL_RECIPIENT_SETTING_KEY, DEFAULT_COMPLETION_EMAIL);
 }
 
 async function initDatabase() {
@@ -165,6 +309,11 @@ async function initDatabase() {
       initials TEXT NOT NULL,
       created_at TEXT NOT NULL,
       password_hash TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
     );
   `);
 
@@ -270,6 +419,7 @@ async function initDatabase() {
   }
 
   await ensureDefaultAdmin();
+  await ensureDefaultEmailRecipient();
 }
 
 function normalizeActivityDetails(details) {
@@ -350,13 +500,7 @@ async function mergeCreationAndCompletionActivity(courseId, completionUser, comp
   );
 }
 
-const emailTransport = nodemailer.createTransport({
-  streamTransport: true,
-  newline: 'unix',
-  buffer: true,
-});
-
-async function recordEmail(courseId, to, subject, body, attachmentBuffer, attachmentName = 'bon-transport.jpg') {
+async function recordEmail(courseId, to, subject, body, attachmentBuffer, attachmentName = EMAIL_ATTACHMENT_NAME) {
   const createdAt = new Date().toISOString();
   let attachmentPath = null;
 
@@ -372,36 +516,72 @@ async function recordEmail(courseId, to, subject, body, attachmentBuffer, attach
 }
 
 async function sendCompletionEmail(course, driver, completionComments, photoDataUrl) {
-  const to = 'laurent.saquet@agriholann.com';
-  const subject = `[Livraison] ${driver.first_name} ${driver.last_name} - ${course.destination}`;
-  const body = `Le chauffeur ${driver.first_name} ${driver.last_name} a effectué sa course du ${new Date(
-    course.date_time
-  ).toLocaleString('fr-FR')}\n\nCommentaires: ${completionComments || 'Aucun commentaire'}`;
+  const to = await getCompletionEmailRecipient();
 
-  let attachmentBuffer = null;
-  if (photoDataUrl && photoDataUrl.startsWith('data:image')) {
-    const base64Data = photoDataUrl.split(',')[1];
-    attachmentBuffer = Buffer.from(base64Data, 'base64');
+  if (!to) {
+    throw new Error('Aucun destinataire configuré pour les emails de validation.');
   }
 
-  await recordEmail(course.id, to, subject, body, attachmentBuffer);
+  const driverFirstName = driver?.first_name || driver?.firstName || '';
+  const driverLastName = driver?.last_name || driver?.lastName || '';
+  const driverLabel = `${driverFirstName} ${driverLastName}`.trim() || 'Chauffeur';
+  const destination = course.destination || 'Destination inconnue';
+  const dateTime = course.date_time || course.dateTime || new Date().toISOString();
+  const dateLabel = new Date(dateTime).toLocaleString('fr-FR');
+  const comments = completionComments || 'Aucun commentaire';
 
-  await emailTransport.sendMail({
-    from: 'no-reply@agriholann.com',
+  const subject = `[Livraison] ${driverLabel} - ${destination}`;
+  const body = `Le chauffeur ${driverLabel} a effectué sa course du ${dateLabel}\n\nCommentaires: ${comments}`;
+
+  const baseAttachmentName = EMAIL_ATTACHMENT_NAME.includes('.')
+    ? EMAIL_ATTACHMENT_NAME.slice(0, EMAIL_ATTACHMENT_NAME.lastIndexOf('.'))
+    : EMAIL_ATTACHMENT_NAME;
+
+  let attachmentBuffer = null;
+  let attachmentName = EMAIL_ATTACHMENT_NAME;
+  let attachmentMimeType = 'image/jpeg';
+
+  if (photoDataUrl && photoDataUrl.startsWith('data:')) {
+    const [header, data] = photoDataUrl.split(',');
+    const mimeMatch = header.match(/^data:(.*?);base64$/);
+    if (mimeMatch && mimeMatch[1]) {
+      attachmentMimeType = mimeMatch[1];
+      const extension = attachmentMimeType.split('/')[1] || 'jpg';
+      attachmentName = `${baseAttachmentName}.${extension}`;
+    }
+    attachmentBuffer = Buffer.from(data, 'base64');
+  } else if (course.photo_path) {
+    try {
+      attachmentBuffer = await fs.promises.readFile(course.photo_path);
+      const extension = path.extname(course.photo_path) || '.jpg';
+      attachmentName = `${baseAttachmentName}${extension}`;
+      const lowerExtension = extension.toLowerCase();
+      if (lowerExtension === '.png') {
+        attachmentMimeType = 'image/png';
+      } else if (lowerExtension === '.jpg' || lowerExtension === '.jpeg') {
+        attachmentMimeType = 'image/jpeg';
+      } else if (lowerExtension === '.pdf') {
+        attachmentMimeType = 'application/pdf';
+      } else {
+        attachmentMimeType = 'application/octet-stream';
+      }
+    } catch (error) {
+      console.warn('Impossible de lire la photo associée à la course pour la pièce jointe', error);
+    }
+  }
+
+  const response = await sendGmailMessage({
     to,
     subject,
     text: body,
-    attachments: attachmentBuffer
-      ? [
-          {
-            filename: 'bon-transport.jpg',
-            content: attachmentBuffer,
-          },
-        ]
-      : [],
+    attachmentBuffer,
+    attachmentName,
+    attachmentMimeType,
   });
 
-  return { to, subject, body };
+  await recordEmail(course.id, to, subject, body, attachmentBuffer, attachmentName);
+
+  return { to, subject, body, messageId: response?.id || null };
 }
 
 app.use(cors());
@@ -533,6 +713,38 @@ app.post('/api/admins', async (req, res) => {
   } catch (error) {
     console.error('Error creating admin', error);
     res.status(500).json({ message: "Erreur lors de la création du compte administrateur" });
+  }
+});
+
+app.get('/api/settings/email-recipient', async (req, res) => {
+  try {
+    const email = await getCompletionEmailRecipient();
+    res.json({ email });
+  } catch (error) {
+    console.error('Error fetching email recipient setting', error);
+    res
+      .status(500)
+      .json({ message: "Erreur lors de la récupération de l'adresse email de réception" });
+  }
+});
+
+app.put('/api/settings/email-recipient', async (req, res) => {
+  try {
+    const { email } = req.body;
+    const normalizedEmail = typeof email === 'string' ? email.trim() : '';
+
+    if (!isValidEmail(normalizedEmail)) {
+      return res.status(400).json({ message: 'Adresse email invalide.' });
+    }
+
+    await setSettingValue(EMAIL_RECIPIENT_SETTING_KEY, normalizedEmail);
+
+    res.json({ email: normalizedEmail });
+  } catch (error) {
+    console.error('Error updating email recipient setting', error);
+    res
+      .status(500)
+      .json({ message: "Erreur lors de la mise à jour de l'adresse email de réception" });
   }
 });
 
@@ -897,7 +1109,9 @@ app.post('/api/courses/:id/complete', async (req, res) => {
     res.json({ message: 'Course complétée', email: completionEmail });
   } catch (error) {
     console.error('Error completing course', error);
-    res.status(500).json({ message: 'Erreur lors de la validation de la course' });
+    res
+      .status(500)
+      .json({ message: error.message || 'Erreur lors de la validation de la course' });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -13,10 +13,51 @@ const DB_PATH = path.join(__dirname, 'db', 'agriholann.db');
 const ATTACHMENTS_DIR = path.join(__dirname, 'storage', 'attachments');
 const DEFAULT_ADMIN_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'admin';
 const DEFAULT_COMPLETION_EMAIL = process.env.DEFAULT_COMPLETION_EMAIL || 'laurent.saquet@agriholann.com';
-const GMAIL_CLIENT_ID = process.env.GMAIL_CLIENT_ID || '';
-const GMAIL_CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || '';
-const GMAIL_REDIRECT_URI = process.env.GMAIL_REDIRECT_URI || 'http://localhost';
-const GMAIL_REFRESH_TOKEN = process.env.GMAIL_REFRESH_TOKEN || '';
+
+function loadGmailConfig() {
+  const config = {
+    clientId: '',
+    clientSecret: '',
+    redirectUri: '',
+    refreshToken: '',
+  };
+
+  const credentialsPath = process.env.GMAIL_CREDENTIALS_PATH || path.join(__dirname, 'credentials.json');
+  const tokenPath = process.env.GMAIL_TOKEN_PATH || path.join(__dirname, 'token.json');
+
+  if (fs.existsSync(credentialsPath)) {
+    try {
+      const rawCredentials = JSON.parse(fs.readFileSync(credentialsPath, 'utf8'));
+      const oauthConfig = rawCredentials.web || rawCredentials.installed || {};
+      config.clientId = oauthConfig.client_id || config.clientId;
+      config.clientSecret = oauthConfig.client_secret || config.clientSecret;
+      if (Array.isArray(oauthConfig.redirect_uris) && oauthConfig.redirect_uris.length > 0) {
+        config.redirectUri = oauthConfig.redirect_uris[0];
+      }
+    } catch (error) {
+      console.error('Impossible de lire credentials.json :', error.message);
+    }
+  }
+
+  if (fs.existsSync(tokenPath)) {
+    try {
+      const token = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
+      config.refreshToken = token.refresh_token || config.refreshToken;
+    } catch (error) {
+      console.error('Impossible de lire token.json :', error.message);
+    }
+  }
+
+  return config;
+}
+
+const gmailFileConfig = loadGmailConfig();
+
+const GMAIL_CLIENT_ID = process.env.GMAIL_CLIENT_ID || gmailFileConfig.clientId || '';
+const GMAIL_CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET || gmailFileConfig.clientSecret || '';
+const GMAIL_REDIRECT_URI =
+  process.env.GMAIL_REDIRECT_URI || gmailFileConfig.redirectUri || 'http://localhost';
+const GMAIL_REFRESH_TOKEN = process.env.GMAIL_REFRESH_TOKEN || gmailFileConfig.refreshToken || '';
 const GMAIL_SENDER = process.env.GMAIL_SENDER || 'chauffeur.agriholann@gmail.com';
 const EMAIL_RECIPIENT_SETTING_KEY = 'completion_email_recipient';
 const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
@@ -142,7 +183,9 @@ async function sendGmailMessage({
   const service = getGmailService();
 
   if (!service) {
-    throw new Error('Configuration de la messagerie Gmail manquante. Veuillez vérifier les identifiants OAuth.');
+    throw new Error(
+      'Configuration de la messagerie Gmail manquante. Définissez les variables GMAIL_* ou fournissez credentials.json et token.json.'
+    );
   }
 
   const rawMessage = buildMimeMessage({

--- a/server.js
+++ b/server.js
@@ -1106,6 +1106,125 @@ app.post('/api/admins', async (req, res) => {
   }
 });
 
+app.put('/api/admins/:id', async (req, res) => {
+  try {
+    const adminId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(adminId)) {
+      return res.status(400).json({ message: 'Identifiant administrateur invalide.' });
+    }
+
+    const sessionInfo = await enforceAdminSession(req, res, { requireSuperAdmin: true });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const existing = await db.get(
+      'SELECT id, first_name, last_name, identifier, role, created_at FROM admins WHERE id = ?',
+      [adminId]
+    );
+
+    if (!existing) {
+      return res.status(404).json({ message: 'Compte administrateur introuvable.' });
+    }
+
+    if (existing.identifier.toLowerCase() === SUPER_ADMIN_IDENTIFIER) {
+      return res.status(400).json({ message: 'Le compte super administrateur ne peut pas être modifié.' });
+    }
+
+    const { firstName, lastName, identifier, role } = req.body || {};
+
+    const trimmedFirstName = typeof firstName === 'string' ? firstName.trim() : '';
+    const trimmedLastName = typeof lastName === 'string' ? lastName.trim() : '';
+    const normalizedIdentifier = typeof identifier === 'string' ? identifier.trim().toLowerCase() : '';
+    const normalizedRole = typeof role === 'string' ? role.trim().toLowerCase() : existing.role;
+
+    if (!trimmedFirstName || !trimmedLastName || !normalizedIdentifier) {
+      return res.status(400).json({ message: 'Prénom, nom et identifiant sont obligatoires.' });
+    }
+
+    if (normalizedIdentifier === SUPER_ADMIN_IDENTIFIER) {
+      return res.status(400).json({ message: "Cet identifiant est réservé au super administrateur." });
+    }
+
+    if (!ADMIN_CREATABLE_ROLES.includes(normalizedRole)) {
+      return res.status(400).json({ message: 'Niveau administrateur invalide.' });
+    }
+
+    const identifierOwner = await db.get(
+      'SELECT id FROM admins WHERE LOWER(identifier) = ? LIMIT 1',
+      [normalizedIdentifier]
+    );
+
+    if (identifierOwner && identifierOwner.id !== adminId) {
+      return res.status(409).json({ message: "Cet identifiant est déjà utilisé par un autre administrateur." });
+    }
+
+    const updates = [];
+    const params = [];
+
+    if (existing.first_name !== trimmedFirstName) {
+      updates.push('first_name = ?');
+      params.push(trimmedFirstName);
+    }
+
+    if (existing.last_name !== trimmedLastName) {
+      updates.push('last_name = ?');
+      params.push(trimmedLastName);
+    }
+
+    if (existing.identifier.toLowerCase() !== normalizedIdentifier) {
+      updates.push('identifier = ?');
+      params.push(normalizedIdentifier);
+    }
+
+    if (existing.role !== normalizedRole) {
+      updates.push('role = ?');
+      params.push(normalizedRole);
+    }
+
+    const initials = buildAdminInitials(trimmedFirstName, trimmedLastName);
+
+    if (existing.first_name !== trimmedFirstName || existing.last_name !== trimmedLastName) {
+      updates.push('initials = ?');
+      params.push(initials);
+    }
+
+    if (!updates.length) {
+      const admin = {
+        id: existing.id,
+        firstName: existing.first_name,
+        lastName: existing.last_name,
+        identifier: existing.identifier,
+        initials,
+        role: existing.role,
+        createdAt: existing.created_at,
+      };
+      return res.json(admin);
+    }
+
+    await db.run(`UPDATE admins SET ${updates.join(', ')} WHERE id = ?`, [...params, adminId]);
+
+    const updated = await db.get(
+      'SELECT id, first_name, last_name, identifier, initials, created_at, role FROM admins WHERE id = ?',
+      [adminId]
+    );
+
+    res.json({
+      id: updated.id,
+      firstName: updated.first_name,
+      lastName: updated.last_name,
+      identifier: updated.identifier,
+      initials: updated.initials,
+      createdAt: updated.created_at,
+      role: updated.role,
+    });
+    broadcastEvent('admins:updated', { action: 'updated', adminId });
+  } catch (error) {
+    console.error('Error updating admin', error);
+    res.status(500).json({ message: "Erreur lors de la mise à jour du compte administrateur" });
+  }
+});
+
 app.delete('/api/admins/:id', async (req, res) => {
   try {
     const adminId = parseInt(req.params.id, 10);

--- a/server.js
+++ b/server.js
@@ -6,12 +6,20 @@ const { google } = require('googleapis');
 const sqlite3 = require('sqlite3').verbose();
 const { open } = require('sqlite');
 const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 const DB_PATH = path.join(__dirname, 'db', 'agriholann.db');
 const ATTACHMENTS_DIR = path.join(__dirname, 'storage', 'attachments');
-const DEFAULT_ADMIN_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'admin';
+const FALLBACK_ADMIN_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'admin';
+const SUPER_ADMIN_DEFAULT_PASSWORD = process.env.SUPER_ADMIN_DEFAULT_PASSWORD || 'lannion';
+const SUPER_ADMIN_IDENTIFIER = 'lsaquet';
+const SUPER_ADMIN_FIRST_NAME = 'Laurent';
+const SUPER_ADMIN_LAST_NAME = 'Saquet';
+const ADMIN_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+const ADMIN_CREATABLE_ROLES = ['manager', 'standard'];
+const ADMIN_ROLES = new Set(['superadmin', ...ADMIN_CREATABLE_ROLES]);
 const DEFAULT_COMPLETION_EMAIL = process.env.DEFAULT_COMPLETION_EMAIL || 'laurent.saquet@agriholann.com';
 const DEFAULT_GMAIL_REDIRECT_URI = 'http://localhost';
 const GMAIL_SENDER = process.env.GMAIL_SENDER || 'chauffeur.agriholann@gmail.com';
@@ -84,6 +92,72 @@ function loadGmailConfig() {
 }
 const EMAIL_RECIPIENT_SETTING_KEY = 'completion_email_recipient';
 const EMAIL_ATTACHMENT_NAME = 'bon-transport.jpg';
+
+const activeAdminSessions = new Map();
+
+function generateAdminSessionToken() {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function createAdminSession(admin) {
+  const token = generateAdminSessionToken();
+  activeAdminSessions.set(token, {
+    adminId: admin.id,
+    expiresAt: Date.now() + ADMIN_SESSION_TTL_MS,
+  });
+  return token;
+}
+
+async function enforceAdminSession(req, res, options = {}) {
+  const token = req.headers['x-admin-token'];
+  if (!token) {
+    res.status(401).json({ message: 'Authentification administrateur requise.' });
+    return null;
+  }
+
+  const session = activeAdminSessions.get(token);
+  if (!session) {
+    res.status(401).json({ message: 'Session administrateur invalide.' });
+    return null;
+  }
+
+  if (session.expiresAt <= Date.now()) {
+    activeAdminSessions.delete(token);
+    res.status(401).json({ message: 'Session administrateur expirée.' });
+    return null;
+  }
+
+  const admin = await db.get(
+    'SELECT id, first_name, last_name, identifier, initials, role FROM admins WHERE id = ?',
+    [session.adminId]
+  );
+
+  if (!admin) {
+    activeAdminSessions.delete(token);
+    res.status(401).json({ message: 'Compte administrateur introuvable.' });
+    return null;
+  }
+
+  if (options.requireSuperAdmin && admin.identifier.toLowerCase() !== SUPER_ADMIN_IDENTIFIER) {
+    res.status(403).json({ message: 'Seul Laurent Saquet peut effectuer cette action.' });
+    return null;
+  }
+
+  if (options.allowSelfOnly && admin.id !== options.allowSelfOnly) {
+    res.status(403).json({ message: 'Action non autorisée pour ce compte administrateur.' });
+    return null;
+  }
+
+  if (options.allowRoles && !options.allowRoles.includes(admin.role)) {
+    res.status(403).json({ message: 'Droits administrateur insuffisants pour cette action.' });
+    return null;
+  }
+
+  session.expiresAt = Date.now() + ADMIN_SESSION_TTL_MS;
+  activeAdminSessions.set(token, session);
+
+  return { admin, token };
+}
 
 async function hashPassword(password) {
   const value = password || '';
@@ -389,24 +463,70 @@ async function generateUniqueAdminIdentifier(firstName, lastName) {
   }
 }
 
-async function ensureDefaultAdmin() {
-  const existing = await db.get('SELECT COUNT(*) as count FROM admins');
-  if (existing.count > 0) {
+async function ensureSuperAdmin() {
+  let admin = await db.get('SELECT * FROM admins WHERE LOWER(identifier) = ?', [SUPER_ADMIN_IDENTIFIER]);
+
+  const expectedInitials = buildAdminInitials(SUPER_ADMIN_FIRST_NAME, SUPER_ADMIN_LAST_NAME);
+
+  if (!admin) {
+    const identifier = SUPER_ADMIN_IDENTIFIER;
+    const initials = expectedInitials;
+    const createdAt = new Date().toISOString();
+    const passwordHash = await hashPassword(SUPER_ADMIN_DEFAULT_PASSWORD);
+
+    await db.run(
+      `INSERT INTO admins (first_name, last_name, identifier, initials, created_at, password_hash, role)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        SUPER_ADMIN_FIRST_NAME,
+        SUPER_ADMIN_LAST_NAME,
+        identifier,
+        initials,
+        createdAt,
+        passwordHash,
+        'superadmin',
+      ]
+    );
     return;
   }
 
-  const firstName = 'Laurent';
-  const lastName = 'Saquet';
-  const identifier = await generateUniqueAdminIdentifier(firstName, lastName);
-  const initials = buildAdminInitials(firstName, lastName);
-  const createdAt = new Date().toISOString();
-  const passwordHash = await hashPassword(DEFAULT_ADMIN_PASSWORD);
+  const updates = [];
+  const params = [];
 
-  await db.run(
-    `INSERT INTO admins (first_name, last_name, identifier, initials, created_at, password_hash)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [firstName, lastName, identifier, initials, createdAt, passwordHash]
-  );
+  if (admin.first_name !== SUPER_ADMIN_FIRST_NAME) {
+    updates.push('first_name = ?');
+    params.push(SUPER_ADMIN_FIRST_NAME);
+  }
+
+  if (admin.last_name !== SUPER_ADMIN_LAST_NAME) {
+    updates.push('last_name = ?');
+    params.push(SUPER_ADMIN_LAST_NAME);
+  }
+
+  if (admin.initials !== expectedInitials) {
+    updates.push('initials = ?');
+    params.push(expectedInitials);
+  }
+
+  if (admin.identifier.toLowerCase() !== SUPER_ADMIN_IDENTIFIER) {
+    updates.push('identifier = ?');
+    params.push(SUPER_ADMIN_IDENTIFIER);
+  }
+
+  if (!admin.password_hash || !admin.password_hash.trim()) {
+    updates.push('password_hash = ?');
+    params.push(await hashPassword(SUPER_ADMIN_DEFAULT_PASSWORD));
+  }
+
+  if (admin.role !== 'superadmin') {
+    updates.push("role = 'superadmin'");
+  }
+
+  if (updates.length) {
+    const setClause = updates.join(', ');
+    params.push(admin.id);
+    await db.run(`UPDATE admins SET ${setClause} WHERE id = ?`, params);
+  }
 }
 
 async function ensureDefaultEmailRecipient() {
@@ -430,7 +550,8 @@ async function initDatabase() {
       first_name TEXT NOT NULL,
       last_name TEXT NOT NULL,
       email TEXT,
-      phone TEXT
+      phone TEXT,
+      password_hash TEXT
     );
 
     CREATE TABLE IF NOT EXISTS courses (
@@ -478,7 +599,8 @@ async function initDatabase() {
       identifier TEXT NOT NULL UNIQUE,
       initials TEXT NOT NULL,
       created_at TEXT NOT NULL,
-      password_hash TEXT
+      password_hash TEXT,
+      role TEXT NOT NULL DEFAULT 'standard'
     );
 
     CREATE TABLE IF NOT EXISTS settings (
@@ -489,18 +611,22 @@ async function initDatabase() {
 
   await ensureColumn('courses', 'archived_at', 'TEXT');
   await ensureColumn('admins', 'password_hash', 'TEXT');
+  await ensureColumn("admins", 'role', "TEXT NOT NULL DEFAULT 'standard'");
+  await ensureColumn('drivers', 'password_hash', 'TEXT');
 
   const adminsWithoutPassword = await db.all(
     "SELECT id FROM admins WHERE password_hash IS NULL OR TRIM(password_hash) = ''"
   );
 
   if (adminsWithoutPassword.length) {
-    const fallbackHash = await hashPassword(DEFAULT_ADMIN_PASSWORD);
+    const fallbackHash = await hashPassword(FALLBACK_ADMIN_PASSWORD);
     const updatePromises = adminsWithoutPassword.map((admin) =>
       db.run('UPDATE admins SET password_hash = ? WHERE id = ?', [fallbackHash, admin.id])
     );
     await Promise.all(updatePromises);
   }
+
+  await db.run("UPDATE admins SET role = 'standard' WHERE role IS NULL OR TRIM(role) = ''");
 
   const driverCount = await db.get('SELECT COUNT(*) as count FROM drivers');
   if (driverCount.count === 0) {
@@ -588,7 +714,7 @@ async function initDatabase() {
     }
   }
 
-  await ensureDefaultAdmin();
+  await ensureSuperAdmin();
   await ensureDefaultEmailRecipient();
   await ensureDefaultGmailSettings();
 }
@@ -763,7 +889,8 @@ app.use(express.static(path.join(__dirname)));
 app.get('/api/drivers', async (req, res) => {
   try {
     const { search } = req.query;
-    let query = 'SELECT id, first_name, last_name, email, phone FROM drivers';
+    let query =
+      "SELECT id, first_name, last_name, email, phone, CASE WHEN password_hash IS NULL OR TRIM(password_hash) = '' THEN 0 ELSE 1 END AS has_password FROM drivers";
     const params = [];
 
     if (search) {
@@ -784,6 +911,13 @@ app.get('/api/drivers', async (req, res) => {
 
 app.post('/api/drivers', async (req, res) => {
   try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
     const { firstName, lastName, email, phone } = req.body;
 
     if (!firstName || !lastName) {
@@ -805,6 +939,13 @@ app.post('/api/drivers', async (req, res) => {
 
 app.delete('/api/drivers/:id', async (req, res) => {
   try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
     const driverId = req.params.id;
     const driver = await db.get('SELECT * FROM drivers WHERE id = ?', [driverId]);
 
@@ -823,7 +964,7 @@ app.delete('/api/drivers/:id', async (req, res) => {
 app.get('/api/admins', async (req, res) => {
   try {
     const rows = await db.all(
-      `SELECT id, first_name, last_name, identifier, initials, created_at FROM admins ORDER BY last_name ASC, first_name ASC`
+      `SELECT id, first_name, last_name, identifier, initials, created_at, role FROM admins ORDER BY last_name ASC, first_name ASC`
     );
 
     res.json(
@@ -834,6 +975,7 @@ app.get('/api/admins', async (req, res) => {
         identifier: admin.identifier,
         initials: admin.initials,
         createdAt: admin.created_at,
+        role: admin.role,
       }))
     );
   } catch (error) {
@@ -844,7 +986,12 @@ app.get('/api/admins', async (req, res) => {
 
 app.post('/api/admins', async (req, res) => {
   try {
-    const { firstName, lastName, password } = req.body;
+    const sessionInfo = await enforceAdminSession(req, res, { requireSuperAdmin: true });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const { firstName, lastName, password, role } = req.body || {};
 
     if (!firstName || !lastName) {
       return res.status(400).json({ message: 'Le prénom et le nom sont obligatoires.' });
@@ -852,6 +999,12 @@ app.post('/api/admins', async (req, res) => {
 
     if (!password) {
       return res.status(400).json({ message: 'Le mot de passe administrateur est obligatoire.' });
+    }
+
+    const normalizedRole = typeof role === 'string' ? role.trim().toLowerCase() : 'standard';
+
+    if (!ADMIN_CREATABLE_ROLES.includes(normalizedRole)) {
+      return res.status(400).json({ message: 'Niveau administrateur invalide.' });
     }
 
     const identifier = await generateUniqueAdminIdentifier(firstName, lastName);
@@ -864,14 +1017,15 @@ app.post('/api/admins', async (req, res) => {
     const passwordHash = await hashPassword(password);
 
     const result = await db.run(
-      `INSERT INTO admins (first_name, last_name, identifier, initials, created_at, password_hash)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-      [firstName.trim(), lastName.trim(), identifier, initials, createdAt, passwordHash]
+      `INSERT INTO admins (first_name, last_name, identifier, initials, created_at, password_hash, role)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [firstName.trim(), lastName.trim(), identifier, initials, createdAt, passwordHash, normalizedRole]
     );
 
-    const admin = await db.get('SELECT id, first_name, last_name, identifier, initials, created_at FROM admins WHERE id = ?', [
-      result.lastID,
-    ]);
+    const admin = await db.get(
+      'SELECT id, first_name, last_name, identifier, initials, created_at, role FROM admins WHERE id = ?',
+      [result.lastID]
+    );
 
     res.status(201).json({
       id: admin.id,
@@ -880,6 +1034,7 @@ app.post('/api/admins', async (req, res) => {
       identifier: admin.identifier,
       initials: admin.initials,
       createdAt: admin.created_at,
+      role: admin.role,
     });
   } catch (error) {
     console.error('Error creating admin', error);
@@ -887,8 +1042,89 @@ app.post('/api/admins', async (req, res) => {
   }
 });
 
+app.delete('/api/admins/:id', async (req, res) => {
+  try {
+    const adminId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(adminId)) {
+      return res.status(400).json({ message: 'Identifiant administrateur invalide.' });
+    }
+
+    const sessionInfo = await enforceAdminSession(req, res, { requireSuperAdmin: true });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const target = await db.get('SELECT id, identifier FROM admins WHERE id = ?', [adminId]);
+    if (!target) {
+      return res.status(404).json({ message: 'Compte administrateur introuvable.' });
+    }
+
+    if (target.identifier.toLowerCase() === SUPER_ADMIN_IDENTIFIER) {
+      return res.status(400).json({ message: 'Le compte super administrateur ne peut pas être supprimé.' });
+    }
+
+    await db.run('DELETE FROM admins WHERE id = ?', [adminId]);
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error deleting admin', error);
+    res.status(500).json({ message: "Erreur lors de la suppression du compte administrateur" });
+  }
+});
+
+app.put('/api/admins/:id/password', async (req, res) => {
+  try {
+    const adminId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(adminId)) {
+      return res.status(400).json({ message: 'Identifiant administrateur invalide.' });
+    }
+
+    const sessionInfo = await enforceAdminSession(req, res, { allowSelfOnly: adminId });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const { currentPassword, newPassword } = req.body || {};
+    const trimmedNewPassword = typeof newPassword === 'string' ? newPassword.trim() : '';
+
+    if (!trimmedNewPassword) {
+      return res.status(400).json({ message: 'Veuillez renseigner un nouveau mot de passe.' });
+    }
+
+    const admin = await db.get('SELECT password_hash FROM admins WHERE id = ?', [adminId]);
+    if (!admin) {
+      return res.status(404).json({ message: 'Compte administrateur introuvable.' });
+    }
+
+    if (admin.password_hash && admin.password_hash.trim()) {
+      if (!currentPassword || !currentPassword.trim()) {
+        return res.status(400).json({ message: 'Veuillez renseigner votre mot de passe actuel.' });
+      }
+
+      const isValid = await comparePassword(currentPassword, admin.password_hash);
+      if (!isValid) {
+        return res.status(401).json({ message: 'Mot de passe actuel invalide.' });
+      }
+    }
+
+    const passwordHash = await hashPassword(trimmedNewPassword);
+    await db.run('UPDATE admins SET password_hash = ? WHERE id = ?', [passwordHash, adminId]);
+
+    res.json({ message: 'Mot de passe mis à jour.' });
+  } catch (error) {
+    console.error('Error updating admin password', error);
+    res.status(500).json({ message: 'Erreur lors de la mise à jour du mot de passe administrateur' });
+  }
+});
+
 app.get('/api/settings/email-config', async (req, res) => {
   try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
     const settings = await getEmailSettingsFromDatabase();
     res.json(settings);
   } catch (error) {
@@ -901,6 +1137,13 @@ app.get('/api/settings/email-config', async (req, res) => {
 
 app.put('/api/settings/email-config', async (req, res) => {
   try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
     const {
       recipient,
       gmailClientId,
@@ -943,6 +1186,13 @@ app.put('/api/settings/email-config', async (req, res) => {
 
 app.get('/api/settings/email-recipient', async (req, res) => {
   try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
     const settings = await getEmailSettingsFromDatabase();
     res.json({ email: settings.recipient });
   } catch (error) {
@@ -955,6 +1205,13 @@ app.get('/api/settings/email-recipient', async (req, res) => {
 
 app.put('/api/settings/email-recipient', async (req, res) => {
   try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
     const { email } = req.body || {};
     const normalizedEmail = typeof email === 'string' ? email.trim() : '';
 
@@ -989,7 +1246,7 @@ app.post('/api/admins/login', async (req, res) => {
 
     if (identifier) {
       admin = await db.get(
-        `SELECT id, first_name, last_name, identifier, initials, created_at, password_hash
+        `SELECT id, first_name, last_name, identifier, initials, created_at, password_hash, role
          FROM admins WHERE LOWER(identifier) = ?`,
         [identifier.toLowerCase()]
       );
@@ -997,7 +1254,7 @@ app.post('/api/admins/login', async (req, res) => {
 
     if (!admin && firstName && lastName) {
       admin = await db.get(
-        `SELECT id, first_name, last_name, identifier, initials, created_at, password_hash
+        `SELECT id, first_name, last_name, identifier, initials, created_at, password_hash, role
          FROM admins
          WHERE LOWER(first_name) = ? AND LOWER(last_name) = ?`,
         [firstName.trim().toLowerCase(), lastName.trim().toLowerCase()]
@@ -1013,6 +1270,8 @@ app.post('/api/admins/login', async (req, res) => {
       return res.status(401).json({ message: 'Identifiants administrateur invalides.' });
     }
 
+    const token = createAdminSession(admin);
+
     res.json({
       id: admin.id,
       firstName: admin.first_name,
@@ -1020,6 +1279,8 @@ app.post('/api/admins/login', async (req, res) => {
       identifier: admin.identifier,
       initials: admin.initials,
       createdAt: admin.created_at,
+      role: admin.role,
+      token,
     });
   } catch (error) {
     console.error('Error logging admin', error);
@@ -1027,11 +1288,20 @@ app.post('/api/admins/login', async (req, res) => {
   }
 });
 
+app.post('/api/admins/logout', (req, res) => {
+  const token = req.headers['x-admin-token'];
+  if (token && activeAdminSessions.has(token)) {
+    activeAdminSessions.delete(token);
+  }
+  res.status(204).send();
+});
+
 app.get('/api/drivers/:id', async (req, res) => {
   try {
-    const driver = await db.get('SELECT id, first_name, last_name, email, phone FROM drivers WHERE id = ?', [
-      req.params.id,
-    ]);
+    const driver = await db.get(
+      "SELECT id, first_name, last_name, email, phone, CASE WHEN password_hash IS NULL OR TRIM(password_hash) = '' THEN 0 ELSE 1 END AS has_password FROM drivers WHERE id = ?",
+      [req.params.id]
+    );
 
     if (!driver) {
       return res.status(404).json({ message: 'Chauffeur introuvable' });
@@ -1041,6 +1311,132 @@ app.get('/api/drivers/:id', async (req, res) => {
   } catch (error) {
     console.error('Error fetching driver', error);
     res.status(500).json({ message: 'Erreur lors de la récupération du chauffeur' });
+  }
+});
+
+app.post('/api/drivers/login', async (req, res) => {
+  try {
+    const { driverId, password } = req.body || {};
+
+    if (!driverId) {
+      return res.status(400).json({ message: 'Identifiant chauffeur manquant.' });
+    }
+
+    const driver = await db.get('SELECT id, first_name, last_name, email, phone, password_hash FROM drivers WHERE id = ?', [
+      driverId,
+    ]);
+
+    if (!driver) {
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
+    }
+
+    const hasPassword = Boolean(driver.password_hash && driver.password_hash.trim());
+
+    if (hasPassword) {
+      if (!password || !password.trim()) {
+        return res.status(400).json({ message: 'Mot de passe requis pour ce chauffeur.' });
+      }
+
+      const isValid = await comparePassword(password, driver.password_hash);
+      if (!isValid) {
+        return res.status(401).json({ message: 'Mot de passe chauffeur invalide.' });
+      }
+    }
+
+    res.json({
+      id: driver.id,
+      firstName: driver.first_name,
+      lastName: driver.last_name,
+      email: driver.email,
+      phone: driver.phone,
+      hasPassword,
+    });
+  } catch (error) {
+    console.error('Error validating driver login', error);
+    res.status(500).json({ message: 'Erreur lors de la vérification du mot de passe chauffeur' });
+  }
+});
+
+app.get('/api/drivers/credentials', async (req, res) => {
+  try {
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const drivers = await db.all(
+      "SELECT id, first_name, last_name, email, phone, CASE WHEN password_hash IS NULL OR TRIM(password_hash) = '' THEN 0 ELSE 1 END AS has_password FROM drivers ORDER BY last_name ASC, first_name ASC"
+    );
+
+    res.json(drivers);
+  } catch (error) {
+    console.error('Error fetching driver credentials', error);
+    res.status(500).json({ message: 'Erreur lors de la récupération des mots de passe chauffeurs' });
+  }
+});
+
+app.put('/api/drivers/:id/password', async (req, res) => {
+  try {
+    const driverId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(driverId)) {
+      return res.status(400).json({ message: 'Identifiant chauffeur invalide.' });
+    }
+
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const { newPassword } = req.body || {};
+    const trimmedPassword = typeof newPassword === 'string' ? newPassword.trim() : '';
+
+    if (!trimmedPassword) {
+      return res.status(400).json({ message: 'Veuillez renseigner un mot de passe.' });
+    }
+
+    const driver = await db.get('SELECT id FROM drivers WHERE id = ?', [driverId]);
+    if (!driver) {
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
+    }
+
+    const passwordHash = await hashPassword(trimmedPassword);
+    await db.run('UPDATE drivers SET password_hash = ? WHERE id = ?', [passwordHash, driverId]);
+
+    res.json({ id: driverId, hasPassword: true });
+  } catch (error) {
+    console.error('Error setting driver password', error);
+    res.status(500).json({ message: 'Erreur lors de la mise à jour du mot de passe chauffeur' });
+  }
+});
+
+app.delete('/api/drivers/:id/password', async (req, res) => {
+  try {
+    const driverId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(driverId)) {
+      return res.status(400).json({ message: 'Identifiant chauffeur invalide.' });
+    }
+
+    const sessionInfo = await enforceAdminSession(req, res, {
+      allowRoles: Array.from(ADMIN_ROLES),
+    });
+    if (!sessionInfo) {
+      return;
+    }
+
+    const driver = await db.get('SELECT id FROM drivers WHERE id = ?', [driverId]);
+    if (!driver) {
+      return res.status(404).json({ message: 'Chauffeur introuvable.' });
+    }
+
+    await db.run('UPDATE drivers SET password_hash = NULL WHERE id = ?', [driverId]);
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error removing driver password', error);
+    res.status(500).json({ message: 'Erreur lors de la suppression du mot de passe chauffeur' });
   }
 });
 
@@ -1240,8 +1636,14 @@ app.delete('/api/courses/:id', async (req, res) => {
       return res.status(404).json({ message: 'Course introuvable' });
     }
 
+    await logActivity(courseId, 'deleted', user || 'LS', {
+      departure: existing.departure,
+      destination: existing.destination,
+      driverId: existing.driver_id,
+      scheduledAt: existing.date_time,
+    });
+
     await db.run('DELETE FROM courses WHERE id = ?', [courseId]);
-    await logActivity(courseId, 'deleted', user || 'LS', 'Course supprimée');
 
     res.status(204).send();
   } catch (error) {


### PR DESCRIPTION
## Summary
- send course completion emails through the Gmail API with OAuth2 credentials and attachment handling
- store the recipient in a new settings table with REST endpoints and an admin UI tab limited to editing that address
- document the required Gmail environment variables for configuring the mail integration

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d504962e7c832d920cbe320545ee1b